### PR TITLE
.travis.yml: Stop testing 'hmac' on 1.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ sudo: required
 
 matrix:
   include:
-    - env: NAME="hmac MSRV"
-      rust: 1.21.0
-      script: cd hmac && cargo test --verbose
     - rust: 1.27.0
       script: cargo test --verbose --all
     - rust: stable


### PR DESCRIPTION
CI is broken (ostensibly also for `master`) because `typenum` switched to using nested import braces, which are unsupported on 1.21:

https://travis-ci.org/RustCrypto/MACs/jobs/576563817

So it seems 1.21 is below typenum's MSRV. Since we plan on bumping MSRV anyway, this removes the tests for 1.21 so `master` CI passes again.