### PR TITLE
Revert ".travis.yml: Stop testing 'hmac' on 1.21"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 
 matrix:
   include:
+    - env: NAME="hmac MSRV"
+      rust: 1.21.0
+      script: cd hmac && cargo test --verbose
     - rust: 1.27.0
       script: cargo test --verbose --all
     - rust: stable


### PR DESCRIPTION
This reverts commit c75be69ea54bafb8463714ddb04b3cfa3d4fa77c.

Fixed upstream:

https://github.com/paholg/typenum/issues/122