### PR TITLE
poly1305 v0.3.0

### DIFF
--- a/poly1305/CHANGES.md
+++ b/poly1305/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2019-08-26)
+### Changed
+- Switch from `MacResult` to built-in `Tag` type ([#13])
+
+[#13]: https://github.com/RustCrypto/MACs/pull/13
+
 ## 0.2.0 (2019-08-19)
 ### Added
 - `Poly1305::input_padded()` ([#16])

--- a/poly1305/Cargo.toml
+++ b/poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poly1305"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "The Poly1305 universal hash function and message authentication code"


### PR DESCRIPTION
### Changed
- Switch from `MacResult` to built-in `Tag` type ([#13])

 [#13]: https://github.com/RustCrypto/MACs/pull/13