### PR TITLE
daa: 2018 edition and `crypto-mac` crate upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 name = "daa"
 version = "0.1.0"
 dependencies = [
- "crypto-mac 0.7.0",
+ "crypto-mac 0.8.0-pre",
  "des",
 ]
 
@@ -178,11 +178,10 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fca0626eef3fdddbad21650dba1dda86c244ee7d5e650aba0bd3f002a7208c"
+version = "0.4.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers#aa14e7b919a8d4e304ace0af3a487539e1ff5ef8"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ aes = { git = "https://github.com/RustCrypto/block-ciphers" }
 block-cipher = { git = "https://github.com/RustCrypto/traits" }
 crypto-mac = { git = "https://github.com/RustCrypto/traits" }
 dbl = { git = "https://github.com/RustCrypto/utils" }
+des = { git = "https://github.com/RustCrypto/block-ciphers" }

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -8,10 +8,11 @@ documentation = "https://docs.rs/daa"
 repository = "https://github.com/RustCrypto/MACs"
 keywords = ["crypto", "mac", "daa", "fips"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
-crypto-mac = "0.7"
-des = "0.2"
+crypto-mac = "= 0.8.0-pre"
+des = "= 0.4.0-pre"
 
 [dev-dependencies]
-crypto-mac = { version = "0.7", features = ["dev"] }
+crypto-mac = { version = "= 0.8.0-pre", features = ["dev"] }

--- a/daa/benches/mod.rs
+++ b/daa/benches/mod.rs
@@ -1,6 +1,3 @@
 #![feature(test)]
-#[macro_use]
-extern crate crypto_mac;
-extern crate daa;
 
-bench!(daa::Daa);
+crypto_mac::bench!(daa::Daa);

--- a/daa/src/lib.rs
+++ b/daa/src/lib.rs
@@ -6,25 +6,25 @@
 //! # Examples
 //!
 //! ```
-//! use daa::{Daa, Mac};
+//! use daa::{Daa, Mac, NewMac};
 //!
 //! // test from FIPS 113
 //! let key = [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF];
 //! let mut mac = Daa::new_varkey(&key).unwrap();
-//! mac.input(b"7654321 Now is the time for ");
+//! mac.update(b"7654321 Now is the time for ");
 //! let correct = [0xF1, 0xD3, 0x0F, 0x68, 0x49, 0x31, 0x2C, 0xA4];
 //! mac.verify(&correct).unwrap();
 //! ```
+
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-pub extern crate crypto_mac;
-extern crate des;
+
+pub use crypto_mac::{self, Mac, NewMac};
 
 use crypto_mac::generic_array::typenum::Unsigned;
 use crypto_mac::generic_array::GenericArray;
-pub use crypto_mac::Mac;
-use crypto_mac::MacResult;
-use des::block_cipher_trait::BlockCipher;
+use crypto_mac::Output;
+use des::block_cipher::{BlockCipher, NewBlockCipher};
 use des::Des;
 
 use core::fmt;
@@ -39,9 +39,8 @@ pub struct Daa {
     pos: usize,
 }
 
-impl Mac for Daa {
-    type OutputSize = <Des as BlockCipher>::BlockSize;
-    type KeySize = <Des as BlockCipher>::KeySize;
+impl NewMac for Daa {
+    type KeySize = <Des as NewBlockCipher>::KeySize;
 
     fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
         let cipher = Des::new(key);
@@ -51,12 +50,16 @@ impl Mac for Daa {
             pos: 0,
         }
     }
+}
+
+impl Mac for Daa {
+    type OutputSize = <Des as BlockCipher>::BlockSize;
 
     #[inline]
-    fn input(&mut self, mut data: &[u8]) {
+    fn update(&mut self, mut data: &[u8]) {
         let n = <Des as BlockCipher>::BlockSize::to_usize();
-
         let rem = n - self.pos;
+
         if data.len() >= rem {
             let (l, r) = data.split_at(rem);
             data = r;
@@ -93,11 +96,12 @@ impl Mac for Daa {
     }
 
     #[inline]
-    fn result(mut self) -> MacResult<Self::OutputSize> {
+    fn result(mut self) -> Output<Self> {
         if self.pos != 0 {
             self.cipher.encrypt_block(&mut self.buffer);
         }
-        MacResult::new(self.buffer)
+
+        Output::new(self.buffer)
     }
 
     #[inline]
@@ -110,7 +114,7 @@ impl Mac for Daa {
 }
 
 impl fmt::Debug for Daa {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Daa")
     }
 }


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `crypto-mac` v0.8.0-pre crate.