### PR TITLE
Bump all versions to `*-pre`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cmac"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "aes",
  "block-cipher",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "daa"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "crypto-mac",
  "des",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
+version = "0.8.0-pre"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -175,7 +175,7 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "pmac"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "aes",
  "block-cipher",

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daa"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = "Implementation of Data Authentication Algorithm (DAA)"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.7.1"
+version = "0.8.0-pre"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
...to reflect the breaking `crypto-mac` crate update