### PR TITLE
Rename `*result*` to `finalize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "block-buffer"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/utils#a0e48018d38545935152cd1715382bc1984b5699"
+source = "git+https://github.com/RustCrypto/utils#2aae8a40556e166e9ca06aebc944091dda24b769"
 dependencies = [
  "block-padding",
  "byte-tools",
@@ -52,7 +52,7 @@ dependencies = [
 [[package]]
 name = "block-cipher"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/traits#f1ae0b0bf1187f0c0a90bd07caa66710240daca5"
+source = "git+https://github.com/RustCrypto/traits#a853a6fedf7210ed0303651afa29cb56eb64852e"
 dependencies = [
  "generic-array",
 ]
@@ -91,7 +91,7 @@ dependencies = [
 [[package]]
 name = "crypto-mac"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/traits#f1ae0b0bf1187f0c0a90bd07caa66710240daca5"
+source = "git+https://github.com/RustCrypto/traits#a853a6fedf7210ed0303651afa29cb56eb64852e"
 dependencies = [
  "blobby",
  "generic-array",
@@ -109,7 +109,7 @@ dependencies = [
 [[package]]
 name = "dbl"
 version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/utils#a0e48018d38545935152cd1715382bc1984b5699"
+source = "git+https://github.com/RustCrypto/utils#2aae8a40556e166e9ca06aebc944091dda24b769"
 dependencies = [
  "generic-array",
 ]
@@ -127,7 +127,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/traits#f1ae0b0bf1187f0c0a90bd07caa66710240daca5"
+source = "git+https://github.com/RustCrypto/traits#a853a6fedf7210ed0303651afa29cb56eb64852e"
 dependencies = [
  "generic-array",
 ]
@@ -160,7 +160,7 @@ dependencies = [
 [[package]]
 name = "md-5"
 version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/hashes#347f13f9538ddbb10455be90ee8e7773fe605649"
+source = "git+https://github.com/RustCrypto/hashes#55cfbba060fe822ecc51dd6fc2616d0a606d2b9d"
 dependencies = [
  "block-buffer",
  "digest",
@@ -186,7 +186,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/hashes#347f13f9538ddbb10455be90ee8e7773fe605649"
+source = "git+https://github.com/RustCrypto/hashes#55cfbba060fe822ecc51dd6fc2616d0a606d2b9d"
 dependencies = [
  "block-buffer",
  "digest",

--- a/cmac/src/lib.rs
+++ b/cmac/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! // `result` has type `Output` which is a thin wrapper around array of
 //! // bytes for providing constant time equality check
-//! let result = mac.result();
+//! let result = mac.finalize();
 //! // To get underlying array use the `into_bytes` method, but be careful,
 //! // since incorrect use of the tag value may permit timing attacks which
 //! // defeat the security provided by the `Output` wrapper
@@ -32,7 +32,7 @@
 //!
 //! mac.update(b"input message");
 //!
-//! # let tag_bytes = mac.clone().result().into_bytes();
+//! # let tag_bytes = mac.clone().finalize().into_bytes();
 //! // `verify` will return `Ok(())` if tag is correct, `Err(MacError)` otherwise
 //! mac.verify(&tag_bytes).unwrap();
 //! ```
@@ -156,7 +156,7 @@ where
     }
 
     #[inline]
-    fn result(self) -> Output<Self> {
+    fn finalize(self) -> Output<Self> {
         let n = C::BlockSize::to_usize();
         let mut buf = self.buffer.clone();
         if self.pos == n {

--- a/daa/src/lib.rs
+++ b/daa/src/lib.rs
@@ -99,7 +99,7 @@ impl Mac for Daa {
     }
 
     #[inline]
-    fn result(mut self) -> Output<Self> {
+    fn finalize(mut self) -> Output<Self> {
         if self.pos != 0 {
             self.cipher.encrypt_block(&mut self.buffer);
         }

--- a/hmac/src/lib.rs
+++ b/hmac/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! // `result` has type `Output` which is a thin wrapper around array of
 //! // bytes for providing constant time equality check
-//! let result = mac.result();
+//! let result = mac.finalize();
 //! // To get underlying array use `code` method, but be careful, since
 //! // incorrect use of the code value may permit timing attacks which defeat
 //! // the security provided by the `Output`
@@ -41,7 +41,7 @@
 //!
 //! mac.update(b"input message");
 //!
-//! # let code_bytes = mac.clone().result().into_bytes();
+//! # let code_bytes = mac.clone().finalize().into_bytes();
 //! // `verify` will return `Ok(())` if code is correct, `Err(MacError)` otherwise
 //! mac.verify(&code_bytes).unwrap();
 //! ```
@@ -144,7 +144,7 @@ where
         } else {
             let mut digest = D::default();
             digest.update(key);
-            let output = digest.fixed_result();
+            let output = digest.finalize_fixed();
             // `n` is calculated at compile time and will equal
             // D::OutputSize. This is used to ensure panic-free code
             let n = min(output.len(), hmac.i_key_pad.len());
@@ -175,11 +175,11 @@ where
     }
 
     #[inline]
-    fn result(self) -> Output<Self> {
+    fn finalize(self) -> Output<Self> {
         let mut opad_digest = self.opad_digest.clone();
-        let hash = self.digest.fixed_result();
+        let hash = self.digest.finalize_fixed();
         opad_digest.update(&hash);
-        Output::new(opad_digest.fixed_result())
+        Output::new(opad_digest.finalize_fixed())
     }
 
     #[inline]

--- a/pmac/src/lib.rs
+++ b/pmac/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! // `result` has type `Output` which is a thin wrapper around array of
 //! // bytes for providing constant time equality check
-//! let result = mac.result();
+//! let result = mac.finalize();
 //! // To get underlying array use `into_bytes` method, but be careful, since
 //! // incorrect use of the tag value may permit timing attacks which defeat
 //! // the security provided by the `Output` wrapper
@@ -32,7 +32,7 @@
 //!
 //! mac.update(b"input message");
 //!
-//! # let tag_bytes = mac.clone().result().into_bytes();
+//! # let tag_bytes = mac.clone().finalize().into_bytes();
 //! // `verify` will return `Ok(())` if tag is correct, `Err(MacError)` otherwise
 //! mac.verify(&tag_bytes).unwrap();
 //! ```
@@ -229,7 +229,7 @@ where
         }
     }
 
-    fn result(self) -> Output<Self> {
+    fn finalize(self) -> Output<Self> {
         let mut tag = self.tag.clone();
         // Special case for empty input
         if self.pos == 0 {


### PR DESCRIPTION
Implements the API changes from:

https://github.com/RustCrypto/traits/pull/161

The `crypto-mac` crate now uses `update` and `finalize` nomenclature ala the Initialize-Update-Finalize (IUF) interface naming scheme.