### PR TITLE
cmac v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cmac"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "aes",
  "block-cipher",

--- a/cmac/CHANGELOG.md
+++ b/cmac/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.3.0 (2020-06-06)
+### Changed
+- Bump `aes` crate dependency to v0.4 ([#40])
+- Bump `dbl` crate dependency to v0.3 ([#39])
+- Bump `crypto-mac` dependency to v0.8; MSRV 1.41+ ([#30])
+- Rename `result` methods to `finalize` ([#38])
+- Upgrade to Rust 2018 edition ([#30])
+
+[#40]: https://github.com/RustCrypto/MACs/pull/40
+[#39]: https://github.com/RustCrypto/MACs/pull/39
+[#38]: https://github.com/RustCrypto/MACs/pull/38
+[#30]: https://github.com/RustCrypto/MACs/pull/30
+
+## 0.2.0 (2018-10-03)
+
+## 0.1.0 (2017-11-26)

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/cmac/src/lib.rs
+++ b/cmac/src/lib.rs
@@ -1,4 +1,4 @@
-//! Generic implementation of Cipher-based Message Authentication Code (CMAC),
+//! Generic implementation of [Cipher-based Message Authentication Code (CMAC)][1],
 //! otherwise known as OMAC1.
 //!
 //! # Usage
@@ -36,6 +36,8 @@
 //! // `verify` will return `Ok(())` if tag is correct, `Err(MacError)` otherwise
 //! mac.verify(&tag_bytes).unwrap();
 //! ```
+//!
+//! [1]: https://en.wikipedia.org/wiki/One-key_MAC
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]


### PR DESCRIPTION
### Changed
- Bump `aes` crate dependency to v0.4 ([#40])
- Bump `dbl` crate dependency to v0.3 ([#39])
- Bump `crypto-mac` dependency to v0.8; MSRV 1.41+ ([#30])
- Rename `result` methods to `finalize` ([#38])
- Upgrade to Rust 2018 edition ([#30])

[#40]: https://github.com/RustCrypto/MACs/pull/40
[#39]: https://github.com/RustCrypto/MACs/pull/39
[#38]: https://github.com/RustCrypto/MACs/pull/38
[#30]: https://github.com/RustCrypto/MACs/pull/30