### PR TITLE
pmac v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "pmac"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "aes",
  "block-cipher",

--- a/pmac/CHANGELOG.md
+++ b/pmac/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.3.0 (2020-06-06)
+### Changed
+- Bump `aes` crate dependency to v0.4 ([#40])
+- Bump `dbl` crate dependency to v0.3 ([#39])
+- Bump `crypto-mac` dependency to v0.8; MSRV 1.41+ ([#34])
+- Rename `result` methods to `finalize` ([#38])
+- Upgrade to Rust 2018 edition ([#34])
+
+[#40]: https://github.com/RustCrypto/MACs/pull/40
+[#39]: https://github.com/RustCrypto/MACs/pull/39
+[#38]: https://github.com/RustCrypto/MACs/pull/38
+[#34]: https://github.com/RustCrypto/MACs/pull/34
+
+## 0.2.0 (2018-10-03)
+
+## 0.1.0 (2017-11-26)

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT/Apache-2.0"

--- a/pmac/src/lib.rs
+++ b/pmac/src/lib.rs
@@ -1,4 +1,4 @@
-//! Generic implementation of Parallelizable Message Authentication Code (PMAC),
+//! Generic implementation of [Parallelizable Message Authentication Code (PMAC)][1],
 //! otherwise known as OMAC1.
 //!
 //! # Usage
@@ -36,6 +36,8 @@
 //! // `verify` will return `Ok(())` if tag is correct, `Err(MacError)` otherwise
 //! mac.verify(&tag_bytes).unwrap();
 //! ```
+//!
+//! [1]: https://en.wikipedia.org/wiki/PMAC_(cryptography)
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]


### PR DESCRIPTION
### Changed
- Bump `aes` crate dependency to v0.4 ([#40])
- Bump `dbl` crate dependency to v0.3 ([#39])
- Bump `crypto-mac` dependency to v0.8; MSRV 1.41+ ([#34])
- Rename `result` methods to `finalize` ([#38])
- Upgrade to Rust 2018 edition ([#34])

[#40]: https://github.com/RustCrypto/MACs/pull/40
[#39]: https://github.com/RustCrypto/MACs/pull/39
[#38]: https://github.com/RustCrypto/MACs/pull/38
[#34]: https://github.com/RustCrypto/MACs/pull/34