### PR TITLE
daa: use `des` v0.4 crate release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,8 +123,9 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.4.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers#268dadc93df08928de3bc510ddf20aabfcc49435"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6f17f2850a27f147a228d342a95bf3c613934464d77d531fe8d5151ccd9362"
 dependencies = [
  "block-cipher",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,5 @@ members = [
 
 [patch.crates-io]
 digest = { git = "https://github.com/RustCrypto/traits" }
-des = { git = "https://github.com/RustCrypto/block-ciphers" }
 md-5 = { git = "https://github.com/RustCrypto/hashes" }
 sha2 = { git = "https://github.com/RustCrypto/hashes" }

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 crypto-mac = "0.8"
-des = "= 0.4.0-pre"
+des = "0.4"
 
 [dev-dependencies]
 crypto-mac = { version = "0.8", features = ["dev"] }


### PR DESCRIPTION
Just published in: https://github.com/RustCrypto/block-ciphers/pull/130