### PR TITLE
hmac v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.8.0-pre"
+version = "0.8.0"
 dependencies = [
  "crypto-mac",
  "digest",

--- a/hmac/CHANGELOG.md
+++ b/hmac/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.8.0 (2020-06-09)
+### Changed
+- Upgrade to `digest` v0.9 crate release; MSRV 1.41 ([#45])
+- Upgrade `crypto-mac` to v0.8 ([#33])
+- Rename `*result*` to `finalize` ([#38])
+- Upgrade to Rust 2018 edition  ([#33])
+
+[#45]: https://github.com/RustCrypto/MACs/pull/45
+[#38]: https://github.com/RustCrypto/MACs/pull/38
+[#33]: https://github.com/RustCrypto/MACs/pull/33
+
+## 0.7.1 (2019-07-11)
+
+## 0.7.0 (2018-10-03)
+
+## 0.6.3 (2018-08-15)
+
+## 0.6.2 (2018-04-15)
+
+## 0.6.1 (2018-04-05)
+
+## 0.6.0 (2018-03-30)
+
+## 0.5.0 (2017-11-15)
+
+## 0.4.2 (2017-07-24)
+
+## 0.4.1 (2017-07-24)
+
+## 0.4.0 (2017-07-24)
+
+## 0.3.1 (2017-06-12)
+
+## 0.1.2 (2017-07-24)
+
+## 0.1.1 (2017-05-14)
+
+## 0.1.0 (2017-05-14)
+
+## 0.0.1 (2016-10-21)

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.8.0-pre"
+version = "0.8.0"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Upgrade to `digest` v0.9 crate release; MSRV 1.41 ([#45])
- Upgrade `crypto-mac` to v0.8 ([#33])
- Rename `*result*` to `finalize` ([#38])
- Upgrade to Rust 2018 edition  ([#33])

[#45]: https://github.com/RustCrypto/MACs/pull/45
[#38]: https://github.com/RustCrypto/MACs/pull/38
[#33]: https://github.com/RustCrypto/MACs/pull/33