### PR TITLE
Add From<BlockCipher> impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cmac"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "block-cipher",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "daa"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crypto-mac",
  "des",
@@ -228,7 +228,7 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "pmac"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "block-cipher",

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.3.0"
+version = "0.3.1"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cmac/src/lib.rs
+++ b/cmac/src/lib.rs
@@ -72,9 +72,8 @@ where
 
 impl<C: BlockCipher> From<C> for Cmac<C>
 where
-    C: BlockCipher + NewBlockCipher + Clone,
+    C: BlockCipher + Clone,
     Block<C::BlockSize>: Dbl,
-    C::BlockSize: Clone,
 {
     fn from(cipher: C) -> Self {
         let mut subkey = GenericArray::default();
@@ -97,7 +96,6 @@ impl<C> NewMac for Cmac<C>
 where
     C: BlockCipher + NewBlockCipher + Clone,
     Block<C::BlockSize>: Dbl,
-    C::BlockSize: Clone,
 {
     type KeySize = C::KeySize;
 
@@ -115,7 +113,6 @@ impl<C> Mac for Cmac<C>
 where
     C: BlockCipher + Clone,
     Block<C::BlockSize>: Dbl,
-    C::BlockSize: Clone,
 {
     type OutputSize = C::BlockSize;
 

--- a/cmac/src/lib.rs
+++ b/cmac/src/lib.rs
@@ -70,12 +70,13 @@ where
     pos: usize,
 }
 
-impl<C> Cmac<C>
+impl<C: BlockCipher> From<C> for Cmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + NewBlockCipher + Clone,
     Block<C::BlockSize>: Dbl,
+    C::BlockSize: Clone,
 {
-    fn from_cipher(cipher: C) -> Self {
+    fn from(cipher: C) -> Self {
         let mut subkey = GenericArray::default();
         cipher.encrypt_block(&mut subkey);
 
@@ -101,12 +102,12 @@ where
     type KeySize = C::KeySize;
 
     fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
-        Self::from_cipher(C::new(key))
+        Self::from(C::new(key))
     }
 
     fn new_varkey(key: &[u8]) -> Result<Self, InvalidKeyLength> {
         let cipher = C::new_varkey(key).map_err(|_| InvalidKeyLength)?;
-        Ok(Self::from_cipher(cipher))
+        Ok(Self::from(cipher))
     }
 }
 

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daa"
-version = "0.2.0"
+version = "0.2.1"
 description = "Implementation of Data Authentication Algorithm (DAA)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/daa/src/lib.rs
+++ b/daa/src/lib.rs
@@ -42,16 +42,22 @@ pub struct Daa {
     pos: usize,
 }
 
-impl NewMac for Daa {
-    type KeySize = <Des as NewBlockCipher>::KeySize;
-
-    fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
-        let cipher = Des::new(key);
+impl From<Des> for Daa {
+    fn from(cipher: Des) -> Self {
         Self {
             cipher,
             buffer: Default::default(),
             pos: 0,
         }
+    }
+}
+
+impl NewMac for Daa {
+    type KeySize = <Des as NewBlockCipher>::KeySize;
+
+    fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
+        Self::from(Des::new(key))
+        
     }
 }
 

--- a/daa/src/lib.rs
+++ b/daa/src/lib.rs
@@ -57,7 +57,6 @@ impl NewMac for Daa {
 
     fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
         Self::from(Des::new(key))
-        
     }
 }
 

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.3.0"
+version = "0.3.1"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pmac/src/lib.rs
+++ b/pmac/src/lib.rs
@@ -141,7 +141,7 @@ where
 
 impl<C> From<C> for Pmac<C>
 where
-    C: BlockCipher + NewBlockCipher + Clone,
+    C: BlockCipher + Clone,
     C::BlockSize: Clone,
     C::ParBlocks: Clone,
     Block<C::BlockSize>: Dbl,

--- a/pmac/src/lib.rs
+++ b/pmac/src/lib.rs
@@ -67,8 +67,6 @@ const LC_SIZE: usize = 20;
 pub struct Pmac<C>
 where
     C: BlockCipher + Clone,
-    C::BlockSize: Clone,
-    C::ParBlocks: Clone,
     Block<C::BlockSize>: Dbl,
 {
     cipher: C,
@@ -84,8 +82,6 @@ where
 impl<C> Pmac<C>
 where
     C: BlockCipher + Clone,
-    C::BlockSize: Clone,
-    C::ParBlocks: Clone,
     Block<C::BlockSize>: Dbl,
 {
     /// Process full buffer and update tag
@@ -142,8 +138,6 @@ where
 impl<C> From<C> for Pmac<C>
 where
     C: BlockCipher + Clone,
-    C::BlockSize: Clone,
-    C::ParBlocks: Clone,
     Block<C::BlockSize>: Dbl,
 {
     fn from(cipher: C) -> Self {
@@ -174,8 +168,6 @@ where
 impl<C> NewMac for Pmac<C>
 where
     C: BlockCipher + NewBlockCipher + Clone,
-    C::BlockSize: Clone,
-    C::ParBlocks: Clone,
     Block<C::BlockSize>: Dbl,
 {
     type KeySize = C::KeySize;
@@ -193,8 +185,6 @@ where
 impl<C> Mac for Pmac<C>
 where
     C: BlockCipher + Clone,
-    C::BlockSize: Clone,
-    C::ParBlocks: Clone,
     Block<C::BlockSize>: Dbl,
 {
     type OutputSize = C::BlockSize;
@@ -294,12 +284,10 @@ where
 impl<C> fmt::Debug for Pmac<C>
 where
     C: BlockCipher + Clone + fmt::Debug,
-    C::BlockSize: Clone,
-    C::ParBlocks: Clone,
     Block<C::BlockSize>: Dbl,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "Pmac-{:?}", self.cipher)
+        write!(f, "Pmac{:?}", self.cipher)
     }
 }
 


### PR DESCRIPTION
Closes #48 

I wonder if we should add the following (feature-gated) impl to the next minor version of `crypto-mac`:
```rust
impl<T> NewMac for T
where T: From<C>, C: BlockCipher
{ .. }
```
It also will allow us to import `block-cipher` from `crypto-mac`, thus a bit simplifying version synchronization.