### PR TITLE
Add io::Write impls

### DIFF
--- a/.github/workflows/cmac.yml
+++ b/.github/workflows/cmac.yml
@@ -51,4 +51,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - run: cargo test --release --no-default-features
       - run: cargo test --release

--- a/.github/workflows/daa.yml
+++ b/.github/workflows/daa.yml
@@ -52,4 +52,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - run: cargo test --release --no-default-features
       - run: cargo test --release

--- a/.github/workflows/hmac.yml
+++ b/.github/workflows/hmac.yml
@@ -52,4 +52,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - run: cargo test --release --no-default-features
       - run: cargo test --release

--- a/.github/workflows/pmac.yml
+++ b/.github/workflows/pmac.yml
@@ -51,4 +51,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - run: cargo test --release --no-default-features
       - run: cargo test --release

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -24,4 +24,4 @@ kuznyechik = "0.4"
 magma = "0.4"
 
 [features]
-std = []
+std = ["crypto-mac/std"]

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -22,3 +22,6 @@ crypto-mac = { version = "0.8", features = ["dev"] }
 aes = "0.4"
 kuznyechik = "0.4"
 magma = "0.4"
+
+[features]
+std = []

--- a/cmac/src/lib.rs
+++ b/cmac/src/lib.rs
@@ -44,6 +44,9 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use crypto_mac::{self, Mac, NewMac};
 
 use block_cipher::generic_array::typenum::Unsigned;
@@ -191,5 +194,21 @@ where
 fn xor<L: ArrayLength<u8>>(buf: &mut Block<L>, data: &Block<L>) {
     for i in 0..L::to_usize() {
         buf[i] ^= data[i];
+    }
+}
+
+#[cfg(feature = "std")]
+impl<C> std::io::Write for Cmac<C>
+where
+    C: BlockCipher + Clone,
+    Block<C::BlockSize>: Dbl,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Mac::update(self, buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -16,3 +16,6 @@ des = "0.4"
 
 [dev-dependencies]
 crypto-mac = { version = "0.8", features = ["dev"] }
+
+[features]
+std = []

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -18,4 +18,4 @@ des = "0.4"
 crypto-mac = { version = "0.8", features = ["dev"] }
 
 [features]
-std = []
+std = ["crypto-mac/std"]

--- a/daa/src/lib.rs
+++ b/daa/src/lib.rs
@@ -22,6 +22,9 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![allow(clippy::needless_range_loop)]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use crypto_mac::{self, Mac, NewMac};
 
 use crypto_mac::generic_array::typenum::Unsigned;
@@ -119,5 +122,17 @@ impl Mac for Daa {
 impl fmt::Debug for Daa {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Daa")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Write for Daa {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Mac::update(self, buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -19,3 +19,6 @@ digest = "0.9"
 crypto-mac = { version = "0.8", features = ["dev"] }
 md-5 = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }
+
+[features]
+std = []

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -21,4 +21,4 @@ md-5 = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 
 [features]
-std = []
+std = ["crypto-mac/std"]

--- a/hmac/src/lib.rs
+++ b/hmac/src/lib.rs
@@ -57,6 +57,9 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use crypto_mac::{self, Mac, NewMac};
 pub use digest;
 
@@ -186,5 +189,22 @@ where
     fn reset(&mut self) {
         self.digest.reset();
         self.digest.update(&self.i_key_pad);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<D> std::io::Write for Hmac<D>
+where
+    D: Update + BlockInput + FixedOutput + Reset + Default + Clone,
+    D::BlockSize: ArrayLength<u8>,
+    D::OutputSize: ArrayLength<u8>,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Mac::update(self, buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -19,3 +19,6 @@ dbl = "0.3"
 [dev-dependencies]
 crypto-mac = { version = "0.8", features = ["dev"] }
 aes = "0.4"
+
+[features]
+std = []

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -21,4 +21,4 @@ crypto-mac = { version = "0.8", features = ["dev"] }
 aes = "0.4"
 
 [features]
-std = []
+std = ["crypto-mac/std"]

--- a/pmac/src/lib.rs
+++ b/pmac/src/lib.rs
@@ -44,6 +44,9 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use crypto_mac::{self, Mac, NewMac};
 
 use block_cipher::generic_array::typenum::Unsigned;
@@ -299,5 +302,21 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Pmac-{:?}", self.cipher)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<C> std::io::Write for Pmac<C>
+where
+    C: BlockCipher + Clone,
+    Block<C::BlockSize>: Dbl,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Mac::update(self, buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes: #8

`impl_write!` can not be applied to generic functions, so `io::Write` is implemented explicitly. I guess we should remove this macro in the next minor version.

For now `std` feature is not enabled by default, since it's a breaking change.