### PR TITLE
Update changelogs

### DIFF
--- a/cmac/CHANGELOG.md
+++ b/cmac/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#57]: https://github.com/RustCrypto/MACs/pull/57
 
+## 0.3.1 (2020-08-12)
+### Added
+- Implement `From<BlockCipher>` ([#54])
+- Implement `io::Write` ([#55])
+
+[#54]: https://github.com/RustCrypto/MACs/pull/54
+[#55]: https://github.com/RustCrypto/MACs/pull/55
+
 ## 0.3.0 (2020-06-06)
 ### Changed
 - Bump `aes` crate dependency to v0.4 ([#40])

--- a/daa/CHANGELOG.md
+++ b/daa/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump `crypto-mac` dependency to v0.9, implement the `FromBlockCipher` trait ([#57])
 
+### Added
+- Implement `io::Write` ([#55])
+
+[#55]: https://github.com/RustCrypto/MACs/pull/55
 [#57]: https://github.com/RustCrypto/MACs/pull/57
 
 ## 0.2.0 (2020-06-08)

--- a/hmac/CHANGELOG.md
+++ b/hmac/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump `crypto-mac` dependency to v0.9 ([#57])
 
+### Added
+- Implement `io::Write` ([#55])
+
+[#55]: https://github.com/RustCrypto/MACs/pull/55
 [#57]: https://github.com/RustCrypto/MACs/pull/57
 
 ## 0.8.1 (2020-06-24)

--- a/pmac/CHANGELOG.md
+++ b/pmac/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump `crypto-mac` dependency to v0.9, implement the `FromBlockCipher` trait ([#57])
 
+### Added
+- `io::Write` impl ([#55])
+
+[#55]: https://github.com/RustCrypto/MACs/pull/55
 [#57]: https://github.com/RustCrypto/MACs/pull/57
 
 ## 0.3.0 (2020-06-06)


### PR DESCRIPTION
I forgot to mention in the changelogs addition of `io::Write` impl. Also I've unintentionally published `cmac v0.3.1`. It has purely additive changes, so no need for yanking.