### PR TITLE
Bump `crypto-mac` dependency to v0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,33 +2,33 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aes"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
 dependencies = [
  "aes-soft",
  "aesni",
- "block-cipher",
+ "cipher",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
+checksum = "8c5ab1fa47ce0ddf44cbd65b1b4e626e3c03b06fd42005603acdc6fa13526296"
 dependencies = [
- "block-cipher",
  "byteorder",
+ "cipher",
  "opaque-debug",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
- "block-cipher",
+ "cipher",
  "opaque-debug",
 ]
 
@@ -48,15 +48,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-cipher"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,8 +60,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cipher"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f7954ae5588102b35257639b1c36a2e7425cc6540fcdb4de19dcb91055d659"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cmac"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "aes",
  "crypto-mac",
@@ -88,19 +88,19 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crypto-mac"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "blobby",
- "block-cipher",
+ "cipher",
  "generic-array",
  "subtle",
 ]
 
 [[package]]
 name = "daa"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "crypto-mac",
  "des",
@@ -117,12 +117,12 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e084b5048dec677e6c9f27d7abc551dde7d127cf4127fea82323c98a30d7fa0d"
+checksum = "b24e7c748888aa2fa8bce21d8c64a52efc810663285315ac7476f7197a982fae"
 dependencies = [
- "block-cipher",
  "byteorder",
+ "cipher",
  "opaque-debug",
 ]
 
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.9.0"
+version = "0.10.0-pre"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -176,21 +176,21 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b14bb5ee0d7f49eb0dad8c4b293b9d2bca7437b931d9dd017f5012814ef6aad"
+checksum = "221139eedf77a90801f17be9f605bb63452436fc4bb5cac0f5b0cd358045115e"
 dependencies = [
- "block-cipher",
+ "cipher",
  "opaque-debug",
 ]
 
 [[package]]
 name = "magma"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fdb2d79916ad493a84edaf2385a8ac587d71ba44c2430322641d5b14725858"
+checksum = "1edfbd7414e5d653305f411bce630430e08906ea0e0e0e42326fd96f24dfe0d1"
 dependencies = [
- "block-cipher",
+ "cipher",
  "opaque-debug",
 ]
 
@@ -213,7 +213,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pmac"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "aes",
  "crypto-mac",

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.4.0"
+version = "0.5.0-pre"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,15 +12,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = { version = "0.9.1", features = ["block-cipher"] }
+crypto-mac = { version = "0.10", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
 hex-literal = "0.2"
-crypto-mac = { version = "0.9.1", features = ["dev"] }
-aes = "0.5"
-kuznyechik = "0.5"
-magma = "0.5"
+crypto-mac = { version = "0.10", features = ["dev"] }
+aes = "0.6"
+kuznyechik = "0.6"
+magma = "0.6"
 
 [features]
 std = ["crypto-mac/std"]

--- a/cmac/src/lib.rs
+++ b/cmac/src/lib.rs
@@ -54,7 +54,7 @@ pub use crypto_mac::{self, FromBlockCipher, Mac, NewMac};
 
 use core::fmt;
 use crypto_mac::{
-    block_cipher::BlockCipher,
+    cipher::BlockCipher,
     generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
     Output,
 };

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daa"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = "Implementation of Data Authentication Algorithm (DAA)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = { version = "0.9.1", features = ["block-cipher"] }
-des = "0.5"
+crypto-mac = { version = "0.10", features = ["cipher"] }
+des = "0.6"
 
 [dev-dependencies]
-crypto-mac = { version = "0.9.1", features = ["dev"] }
+crypto-mac = { version = "0.10", features = ["dev"] }
 
 [features]
 std = ["crypto-mac/std"]

--- a/daa/src/lib.rs
+++ b/daa/src/lib.rs
@@ -32,7 +32,7 @@ pub use crypto_mac::{self, FromBlockCipher, Mac, NewMac};
 
 use core::fmt;
 use crypto_mac::{
-    block_cipher::BlockCipher,
+    cipher::BlockCipher,
     generic_array::{typenum::Unsigned, GenericArray},
     Output,
 };

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.9.0"
+version = "0.10.0-pre"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,11 +12,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = "0.9"
+crypto-mac = "0.10"
 digest = "0.9"
 
 [dev-dependencies]
-crypto-mac = { version = "0.9", features = ["dev"] }
+crypto-mac = { version = "0.10", features = ["dev"] }
 md-5 = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.4.0"
+version = "0.5.0-pre"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,12 +12,12 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = { version = "0.9.1", features = ["block-cipher"] }
+crypto-mac = { version = "0.10", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
-crypto-mac = { version = "0.9.1", features = ["dev"] }
-aes = "0.5"
+crypto-mac = { version = "0.10", features = ["dev"] }
+aes = "0.6"
 
 [features]
 std = ["crypto-mac/std"]

--- a/pmac/src/lib.rs
+++ b/pmac/src/lib.rs
@@ -54,7 +54,7 @@ pub use crypto_mac::{self, FromBlockCipher, Mac, NewMac};
 
 use core::{fmt, slice};
 use crypto_mac::{
-    block_cipher::BlockCipher,
+    cipher::BlockCipher,
     generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
     Output,
 };


### PR DESCRIPTION
This is the first release of `crypto-mac` based on the `cipher` crate.