### PR TITLE
Release new versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "aes",
  "crypto-mac",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "daa"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "crypto-mac",
  "des",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.10.0-pre"
+version = "0.10.0"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -213,7 +213,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pmac"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "aes",
  "crypto-mac",

--- a/cmac/CHANGELOG.md
+++ b/cmac/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-10-16)
+### Changed
+- Bump `crypto-mac` dependency to v0.10 ([#62])
+
+[#62]: https://github.com/RustCrypto/MACs/pull/62
+
 ## 0.4.0 (2020-08-12)
 ### Changed
 - Bump `crypto-mac` dependency to v0.9, implement the `FromBlockCipher` trait ([#57])

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/daa/CHANGELOG.md
+++ b/daa/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2020-10-16)
+### Changed
+- Bump `crypto-mac` dependency to v0.10 ([#62])
+
+[#62]: https://github.com/RustCrypto/MACs/pull/62
+
 ## 0.3.0 (2020-08-12)
 ### Changed
 - Bump `crypto-mac` dependency to v0.9, implement the `FromBlockCipher` trait ([#57])

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daa"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = "Implementation of Data Authentication Algorithm (DAA)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/hmac/CHANGELOG.md
+++ b/hmac/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2020-10-16)
+### Changed
+- Bump `crypto-mac` dependency to v0.10 ([#62])
+
+[#62]: https://github.com/RustCrypto/MACs/pull/62
+
 ## 0.9.0 (2020-08-12)
 ### Changed
 - Bump `crypto-mac` dependency to v0.9 ([#57])

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.10.0-pre"
+version = "0.10.0"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pmac/CHANGELOG.md
+++ b/pmac/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-10-16)
+### Changed
+- Bump `crypto-mac` dependency to v0.10 ([#62])
+
+[#62]: https://github.com/RustCrypto/MACs/pull/62
+
 ## 0.4.0 (2020-08-12)
 ### Changed
 - Bump `crypto-mac` dependency to v0.9, implement the `FromBlockCipher` trait ([#57])

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
These include the `crypto-mac` v0.10 update (#62), which is the first version based on the new `cipher` crate.