### PR TITLE
Bump `crypto-mac` dependency to v0.11.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,33 +2,12 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
 dependencies = [
- "aes-soft",
- "aesni",
+ "cfg-if",
  "cipher",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5ab1fa47ce0ddf44cbd65b1b4e626e3c03b06fd42005603acdc6fa13526296"
-dependencies = [
- "byteorder",
- "cipher",
- "opaque-debug",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher",
+ "cpuid-bool 0.2.0",
  "opaque-debug",
 ]
 
@@ -55,22 +34,22 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.2.1"
+version = "0.3.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f7954ae5588102b35257639b1c36a2e7425cc6540fcdb4de19dcb91055d659"
+checksum = "e1db53c34251ece12ba40366dd5ece6dc5672296d7fb34f7b1791e8f0d449e69"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "cmac"
-version = "0.5.1"
+version = "0.6.0-pre"
 dependencies = [
  "aes",
  "crypto-mac",
@@ -87,10 +66,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
-name = "crypto-mac"
-version = "0.10.0"
+name = "cpuid-bool"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.0-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84f879755fdae65b8692c89c96ed2848c762049e9daa132b145162a88a62887"
 dependencies = [
  "blobby",
  "cipher",
@@ -100,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "daa"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "crypto-mac",
  "des",
@@ -117,9 +102,8 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24e7c748888aa2fa8bce21d8c64a52efc810663285315ac7476f7197a982fae"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
 dependencies = [
  "byteorder",
  "cipher",
@@ -166,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0-pre"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -176,9 +160,8 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221139eedf77a90801f17be9f605bb63452436fc4bb5cac0f5b0cd358045115e"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -186,9 +169,8 @@ dependencies = [
 
 [[package]]
 name = "magma"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edfbd7414e5d653305f411bce630430e08906ea0e0e0e42326fd96f24dfe0d1"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -213,7 +195,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pmac"
-version = "0.5.1"
+version = "0.6.0-pre"
 dependencies = [
  "aes",
  "crypto-mac",
@@ -222,28 +204,28 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "sha2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer",
  "cfg-if",
- "cpuid-bool",
+ "cpuid-bool 0.1.2",
  "digest",
  "opaque-debug",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,9 @@ members = [
     "hmac",
     "pmac",
 ]
+
+[patch.crates-io]
+aes = { git = "https://github.com/RustCrypto/block-ciphers.git" }
+des = { git = "https://github.com/RustCrypto/block-ciphers.git" }
+kuznyechik = { git = "https://github.com/RustCrypto/block-ciphers.git" }
+magma = { git = "https://github.com/RustCrypto/block-ciphers.git" }

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.5.1"
+version = "0.6.0-pre"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,15 +12,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = { version = "0.10", features = ["cipher"] }
+crypto-mac = { version = "0.11.0-pre", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
 hex-literal = "0.2"
-crypto-mac = { version = "0.10", features = ["dev"] }
-aes = "0.6"
-kuznyechik = "0.6"
-magma = "0.6"
+crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
+aes = "0.7.0-pre"
+kuznyechik = "0.7.0-pre"
+magma = "0.7.0-pre"
 
 [features]
 std = ["crypto-mac/std"]

--- a/cmac/src/lib.rs
+++ b/cmac/src/lib.rs
@@ -11,7 +11,7 @@
 //! use cmac::{Cmac, Mac, NewMac};
 //!
 //! // Create `Mac` trait implementation, namely CMAC-AES128
-//! let mut mac = Cmac::<Aes128>::new_varkey(b"very secret key.").unwrap();
+//! let mut mac = Cmac::<Aes128>::new_from_slice(b"very secret key.").unwrap();
 //! mac.update(b"input message");
 //!
 //! // `result` has type `Output` which is a thin wrapper around array of
@@ -28,7 +28,7 @@
 //! ```rust
 //! # use aes::Aes128;
 //! # use cmac::{Cmac, Mac, NewMac};
-//! let mut mac = Cmac::<Aes128>::new_varkey(b"very secret key.").unwrap();
+//! let mut mac = Cmac::<Aes128>::new_from_slice(b"very secret key.").unwrap();
 //!
 //! mac.update(b"input message");
 //!
@@ -54,7 +54,7 @@ pub use crypto_mac::{self, FromBlockCipher, Mac, NewMac};
 
 use core::fmt;
 use crypto_mac::{
-    cipher::BlockCipher,
+    cipher::{BlockCipher, BlockEncrypt},
     generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
     Output,
 };
@@ -66,7 +66,7 @@ type Block<N> = GenericArray<u8, N>;
 #[derive(Clone)]
 pub struct Cmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + BlockEncrypt + Clone,
     Block<C::BlockSize>: Dbl,
 {
     cipher: C,
@@ -78,7 +78,7 @@ where
 
 impl<C> FromBlockCipher for Cmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + BlockEncrypt + Clone,
     Block<C::BlockSize>: Dbl,
 {
     type Cipher = C;
@@ -102,7 +102,7 @@ where
 
 impl<C> Mac for Cmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + BlockEncrypt + Clone,
     Block<C::BlockSize>: Dbl,
 {
     type OutputSize = C::BlockSize;
@@ -168,7 +168,7 @@ where
 
 impl<C> fmt::Debug for Cmac<C>
 where
-    C: BlockCipher + fmt::Debug + Clone,
+    C: BlockCipher + BlockEncrypt + Clone + fmt::Debug,
     Block<C::BlockSize>: Dbl,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
@@ -186,7 +186,7 @@ fn xor<L: ArrayLength<u8>>(buf: &mut Block<L>, data: &Block<L>) {
 #[cfg(feature = "std")]
 impl<C> std::io::Write for Cmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + BlockEncrypt + Clone,
     Block<C::BlockSize>: Dbl,
 {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {

--- a/cmac/tests/gost.rs
+++ b/cmac/tests/gost.rs
@@ -21,7 +21,7 @@ fn cmac_kuznyechik() {
     let mac_res = hex!("
         336f4d296059fbe34ddeb35b37749c67
     ");
-    let mut mac = Cmac::<Kuznyechik>::new_varkey(&key).unwrap();
+    let mut mac = Cmac::<Kuznyechik>::new_from_slice(&key).unwrap();
     mac.update(&pt);
     let tag_bytes = mac.finalize().into_bytes();
     assert_eq!(&tag_bytes[..mac_res.len()], &mac_res);
@@ -39,7 +39,7 @@ fn cmac_magma() {
         4a98fb2e67a8024c8912409b17b57e41
     ");
     let mac_res = hex!("154e72102030c5bb");
-    let mut mac = Cmac::<Magma>::new_varkey(&key).unwrap();
+    let mut mac = Cmac::<Magma>::new_from_slice(&key).unwrap();
     mac.update(&pt);
     let tag_bytes = mac.finalize().into_bytes();
     assert_eq!(&tag_bytes[..mac_res.len()], &mac_res);

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daa"
-version = "0.4.1"
+version = "0.5.0-pre"
 description = "Implementation of Data Authentication Algorithm (DAA)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = { version = "0.10", features = ["cipher"] }
-des = "0.6"
+crypto-mac = { version = "0.11.0-pre", features = ["cipher"] }
+des = "0.7.0-pre"
 
 [dev-dependencies]
-crypto-mac = { version = "0.10", features = ["dev"] }
+crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
 
 [features]
 std = ["crypto-mac/std"]

--- a/daa/src/lib.rs
+++ b/daa/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! // test from FIPS 113
 //! let key = [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF];
-//! let mut mac = Daa::new_varkey(&key).unwrap();
+//! let mut mac = Daa::new_from_slice(&key).unwrap();
 //! mac.update(b"7654321 Now is the time for ");
 //! let correct = [0xF1, 0xD3, 0x0F, 0x68, 0x49, 0x31, 0x2C, 0xA4];
 //! mac.verify(&correct).unwrap();
@@ -32,7 +32,7 @@ pub use crypto_mac::{self, FromBlockCipher, Mac, NewMac};
 
 use core::fmt;
 use crypto_mac::{
-    cipher::BlockCipher,
+    cipher::{BlockCipher, BlockEncrypt},
     generic_array::{typenum::Unsigned, GenericArray},
     Output,
 };

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0-pre"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,11 +12,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = "0.10"
+crypto-mac = "0.11.0-pre"
 digest = "0.9"
 
 [dev-dependencies]
-crypto-mac = { version = "0.10", features = ["dev"] }
+crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
 md-5 = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 

--- a/hmac/src/lib.rs
+++ b/hmac/src/lib.rs
@@ -17,7 +17,7 @@
 //! type HmacSha256 = Hmac<Sha256>;
 //!
 //! // Create HMAC-SHA256 instance which implements `Mac` trait
-//! let mut mac = HmacSha256::new_varkey(b"my secret and secure key")
+//! let mut mac = HmacSha256::new_from_slice(b"my secret and secure key")
 //!     .expect("HMAC can take key of any size");
 //! mac.update(b"input message");
 //!
@@ -36,7 +36,7 @@
 //! # use sha2::Sha256;
 //! # use hmac::{Hmac, Mac, NewMac};
 //! # type HmacSha256 = Hmac<Sha256>;
-//! let mut mac = HmacSha256::new_varkey(b"my secret and secure key")
+//! let mut mac = HmacSha256::new_from_slice(b"my secret and secure key")
 //!     .expect("HMAC can take key of any size");
 //!
 //! mac.update(b"input message");
@@ -124,11 +124,11 @@ where
     type KeySize = D::BlockSize;
 
     fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
-        Self::new_varkey(key.as_slice()).unwrap()
+        Self::new_from_slice(key.as_slice()).unwrap()
     }
 
     #[inline]
-    fn new_varkey(key: &[u8]) -> Result<Self, InvalidKeyLength> {
+    fn new_from_slice(key: &[u8]) -> Result<Self, InvalidKeyLength> {
         let mut hmac = Self {
             digest: Default::default(),
             i_key_pad: GenericArray::generate(|_| IPAD),

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.5.1"
+version = "0.6.0-pre"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,12 +12,12 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = { version = "0.10", features = ["cipher"] }
+crypto-mac = { version = "0.11.0-pre", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
-crypto-mac = { version = "0.10", features = ["dev"] }
-aes = "0.6"
+crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
+aes = "0.7.0-pre"
 
 [features]
 std = ["crypto-mac/std"]

--- a/pmac/src/lib.rs
+++ b/pmac/src/lib.rs
@@ -11,7 +11,7 @@
 //! use pmac::{Pmac, Mac, NewMac};
 //!
 //! // Create `Mac` trait implementation, namely PMAC-AES128
-//! let mut mac = Pmac::<Aes128>::new_varkey(b"very secret key.").unwrap();
+//! let mut mac = Pmac::<Aes128>::new_from_slice(b"very secret key.").unwrap();
 //! mac.update(b"input message");
 //!
 //! // `result` has type `Output` which is a thin wrapper around array of
@@ -28,7 +28,7 @@
 //! ```rust
 //! # use aes::Aes128;
 //! # use pmac::{Pmac, Mac, NewMac};
-//! let mut mac = Pmac::<Aes128>::new_varkey(b"very secret key.").unwrap();
+//! let mut mac = Pmac::<Aes128>::new_from_slice(b"very secret key.").unwrap();
 //!
 //! mac.update(b"input message");
 //!
@@ -54,7 +54,7 @@ pub use crypto_mac::{self, FromBlockCipher, Mac, NewMac};
 
 use core::{fmt, slice};
 use crypto_mac::{
-    cipher::BlockCipher,
+    cipher::{BlockCipher, BlockEncrypt},
     generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
     Output,
 };
@@ -72,7 +72,7 @@ const LC_SIZE: usize = 20;
 #[derive(Clone)]
 pub struct Pmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + BlockEncrypt + Clone,
     Block<C::BlockSize>: Dbl,
 {
     cipher: C,
@@ -87,7 +87,7 @@ where
 
 impl<C> Pmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + BlockEncrypt + Clone,
     Block<C::BlockSize>: Dbl,
 {
     /// Process full buffer and update tag
@@ -143,7 +143,7 @@ where
 
 impl<C> FromBlockCipher for Pmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + BlockEncrypt + Clone,
     Block<C::BlockSize>: Dbl,
 {
     type Cipher = C;
@@ -175,7 +175,7 @@ where
 
 impl<C> Mac for Pmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + BlockEncrypt + Clone,
     Block<C::BlockSize>: Dbl,
 {
     type OutputSize = C::BlockSize;
@@ -274,7 +274,7 @@ where
 
 impl<C> fmt::Debug for Pmac<C>
 where
-    C: BlockCipher + Clone + fmt::Debug,
+    C: BlockCipher + BlockEncrypt + Clone + fmt::Debug,
     Block<C::BlockSize>: Dbl,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
@@ -292,7 +292,7 @@ fn xor<L: ArrayLength<u8>>(buf: &mut Block<L>, data: &Block<L>) {
 #[cfg(feature = "std")]
 impl<C> std::io::Write for Pmac<C>
 where
-    C: BlockCipher + Clone,
+    C: BlockCipher + BlockEncrypt + Clone,
     Block<C::BlockSize>: Dbl,
 {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {


### PR DESCRIPTION
Uses the newly released `cipher` v0.3.0-pre.4