### PR TITLE
Bump `aes` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 [[package]]
 name = "aes"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "des"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
 dependencies = [
  "byteorder",
  "cipher",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "kuznyechik"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -178,7 +178,7 @@ dependencies = [
 [[package]]
 name = "magma"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#3215a921f894f533882dc1a3cf55242237fca4ed"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
 dependencies = [
  "cipher",
  "opaque-debug",

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -16,9 +16,9 @@ crypto-mac = { version = "0.11.0-pre", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
-hex-literal = "0.2"
+aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
-aes = "0.7.0-pre"
+hex-literal = "0.2"
 kuznyechik = "0.7.0-pre"
 magma = "0.7.0-pre"
 

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -16,8 +16,8 @@ crypto-mac = { version = "0.11.0-pre", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
+aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
-aes = "0.7.0-pre"
 
 [features]
 std = ["crypto-mac/std"]


### PR DESCRIPTION
The `aes` crate is used for several tests, and just got an MSRV breaking change in RustCrypto/block-ciphers#216.

This commit bumps the git dependency to test the crates in this repo with the MSRV changes.