### PR TITLE
Bump `crypto-mac` crate dependency to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 [[package]]
 name = "aes"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#db3763260d02187f841ee57a51a83ce60045013d"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -35,9 +35,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cfg-if"
@@ -47,9 +47,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.3.0-pre.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1db53c34251ece12ba40366dd5ece6dc5672296d7fb34f7b1791e8f0d449e69"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
 ]
@@ -80,9 +80,9 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.0-pre"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84f879755fdae65b8692c89c96ed2848c762049e9daa132b145162a88a62887"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "blobby",
  "cipher",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "des"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#db3763260d02187f841ee57a51a83ce60045013d"
 dependencies = [
  "byteorder",
  "cipher",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "kuznyechik"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#db3763260d02187f841ee57a51a83ce60045013d"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -178,7 +178,7 @@ dependencies = [
 [[package]]
 name = "magma"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#7236bce0b75b7bcf719add5e88890bd667ebb95f"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#db3763260d02187f841ee57a51a83ce60045013d"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -248,12 +248,12 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = { version = "0.11.0-pre", features = ["cipher"] }
+crypto-mac = { version = "0.11", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
 aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
-crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
+crypto-mac = { version = "0.11", features = ["dev"] }
 hex-literal = "0.2"
 kuznyechik = "0.7.0-pre"
 magma = "0.7.0-pre"

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = { version = "0.11.0-pre", features = ["cipher"] }
+crypto-mac = { version = "0.11", features = ["cipher"] }
 des = "0.7.0-pre"
 
 [dev-dependencies]
-crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
+crypto-mac = { version = "0.11", features = ["dev"] }
 
 [features]
 std = ["crypto-mac/std"]

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -12,11 +12,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = "0.11.0-pre"
+crypto-mac = "0.11"
 digest = "0.9"
 
 [dev-dependencies]
-crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
+crypto-mac = { version = "0.11", features = ["dev"] }
 md-5 = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 streebog = { version = "0.9", default-features = false }

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crypto-mac = { version = "0.11.0-pre", features = ["cipher"] }
+crypto-mac = { version = "0.11", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
 aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
-crypto-mac = { version = "0.11.0-pre", features = ["dev"] }
+crypto-mac = { version = "0.11", features = ["dev"] }
 
 [features]
 std = ["crypto-mac/std"]


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/622