### PR TITLE
Bump `aes` crate dependency to v0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,12 +2,13 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aes"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#db3763260d02187f841ee57a51a83ce60045013d"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99446914425f48a667458b33c7fb920e24cf9e7c149a072a9fc420731b353835"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpuid-bool 0.2.0",
+ "cpufeatures",
  "opaque-debug",
 ]
 
@@ -67,16 +68,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crypto-mac"
@@ -224,7 +225,7 @@ checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer",
  "cfg-if",
- "cpuid-bool 0.1.2",
+ "cpuid-bool",
  "digest",
  "opaque-debug",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ members = [
 ]
 
 [patch.crates-io]
-aes = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 des = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 kuznyechik = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 magma = { git = "https://github.com/RustCrypto/block-ciphers.git" }

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -16,7 +16,7 @@ crypto-mac = { version = "0.11", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
-aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
+aes = { version = "0.7", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 crypto-mac = { version = "0.11", features = ["dev"] }
 hex-literal = "0.2"
 kuznyechik = "0.7.0-pre"

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -16,7 +16,7 @@ crypto-mac = { version = "0.11", features = ["cipher"] }
 dbl = "0.3"
 
 [dev-dependencies]
-aes = { version = "=0.7.0-pre", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
+aes = { version = "0.7", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 crypto-mac = { version = "0.11", features = ["dev"] }
 
 [features]


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/block-ciphers/pull/238