### PR TITLE
Use v0.7 releases of `des`, `kuznyechik`, and `magma`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,8 +110,9 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#db3763260d02187f841ee57a51a83ce60045013d"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac41dd49fb554432020d52c875fc290e110113f864c6b1b525cd62c7e7747a5d"
 dependencies = [
  "byteorder",
  "cipher",
@@ -169,8 +170,9 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#db3763260d02187f841ee57a51a83ce60045013d"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0865d64349fd4b3aaf478b279af022717585d95780c038919c60fe042aff30b0"
 dependencies = [
  "cipher",
  "opaque-debug",
@@ -178,8 +180,9 @@ dependencies = [
 
 [[package]]
 name = "magma"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#db3763260d02187f841ee57a51a83ce60045013d"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53792c7fca348c3d880c5ab2b0a2378a28edca57d080feabc4b60b4633dff91b"
 dependencies = [
  "cipher",
  "opaque-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,3 @@ members = [
     "hmac",
     "pmac",
 ]
-
-[patch.crates-io]
-des = { git = "https://github.com/RustCrypto/block-ciphers.git" }
-kuznyechik = { git = "https://github.com/RustCrypto/block-ciphers.git" }
-magma = { git = "https://github.com/RustCrypto/block-ciphers.git" }

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -19,8 +19,8 @@ dbl = "0.3"
 aes = { version = "0.7", features = ["force-soft"] } # Uses `force-soft` for MSRV 1.41
 crypto-mac = { version = "0.11", features = ["dev"] }
 hex-literal = "0.2"
-kuznyechik = "0.7.0-pre"
-magma = "0.7.0-pre"
+kuznyechik = "0.7"
+magma = "0.7"
 
 [features]
 std = ["crypto-mac/std"]

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 crypto-mac = { version = "0.11", features = ["cipher"] }
-des = "0.7.0-pre"
+des = "0.7"
 
 [dev-dependencies]
 crypto-mac = { version = "0.11", features = ["dev"] }


### PR DESCRIPTION
Bumps to the following releases (based on `cipher` v0.3):
- `des` v0.7
- `kuznyechik` v0.7
- `magma` v0.7