### PR TITLE
Release new `crypto-mac` v0.11-based versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aes",
  "crypto-mac",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "daa"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "crypto-mac",
  "des",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.11.0-pre"
+version = "0.11.0"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -207,7 +207,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pmac"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "aes",
  "crypto-mac",

--- a/cmac/CHANGELOG.md
+++ b/cmac/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2021-04-29)
+### Changed
+- Bump `crypto-mac` crate dependency to v0.11 ([#73])
+
+[#73]: https://github.com/RustCrypto/MACs/pull/73
+
 ## 0.5.1 (2020-10-16)
 ### Added
 - Zulip badge ([#64])

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/daa/CHANGELOG.md
+++ b/daa/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-04-29)
+### Changed
+- Bump `crypto-mac` crate dependency to v0.11 ([#73])
+- Bump `des` crate dependency to v0.7 ([#75])
+
+[#73]: https://github.com/RustCrypto/MACs/pull/73
+[#75]: https://github.com/RustCrypto/MACs/pull/75
+
 ## 0.4.1 (2020-10-16)
 ### Added
 - Zulip badge ([#64])

--- a/daa/Cargo.toml
+++ b/daa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daa"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = "Implementation of Data Authentication Algorithm (DAA)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/hmac/CHANGELOG.md
+++ b/hmac/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2021-04-29)
+### Changed
+- Bump `crypto-mac` crate dependency to v0.11 ([#73])
+
+[#73]: https://github.com/RustCrypto/MACs/pull/73
+
 ## 0.10.1 (2020-10-16)
 ### Added
 - Zulip badge ([#64])

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.11.0-pre"
+version = "0.11.0"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pmac/CHANGELOG.md
+++ b/pmac/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2021-04-29)
+### Changed
+- Bump `crypto-mac` crate dependency to v0.11 ([#73])
+
+[#73]: https://github.com/RustCrypto/MACs/pull/73
+
 ## 0.5.1 (2020-10-16)
 ### Added
 - Zulip badge ([#64])

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/622