### PR TITLE
Replace unmaintained actions-rs/* actions in CI workflows

### DIFF
--- a/.github/workflows/cbc-mac.yml
+++ b/.github/workflows/cbc-mac.yml
@@ -31,12 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
   minimal-versions:
@@ -54,10 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - run: cargo test --release --no-default-features
       - run: cargo test --release

--- a/.github/workflows/cmac.yml
+++ b/.github/workflows/cmac.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
   minimal-versions:
@@ -53,10 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - run: cargo test --release --no-default-features
       - run: cargo test --release

--- a/.github/workflows/hmac.yml
+++ b/.github/workflows/hmac.yml
@@ -31,12 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
   minimal-versions:
@@ -54,11 +52,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - run: cargo test --release --no-default-features
       - run: cargo test --release --features reset
       - run: cargo test --release

--- a/.github/workflows/pmac.yml
+++ b/.github/workflows/pmac.yml
@@ -30,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
   minimal-versions:
@@ -53,10 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - run: cargo test --release --no-default-features
       - run: cargo test --release

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -15,9 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.56.0 # MSRV
           components: clippy
       - run: cargo clippy --all -- -D warnings
@@ -29,14 +28,10 @@ jobs:
         uses: actions/checkout@v3.4.0
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/RustCrypto/MACs/actions/runs/4471581991:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of some of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), and the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.