### PR TITLE
Revert c68642e; preserve `digest` v0.10.7 bump in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "blobby",
  "block-buffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "blobby",
  "block-buffer",

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 belt-block = { version = "0.1" }
-digest = { version = "0.10.7", features = ["mac"] }
+digest = { version = "0.10.3", features = ["mac"] }
 cipher = "0.4"
 
 [dev-dependencies]

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -12,13 +12,13 @@ repository = "https://github.com/RustCrypto/MACs"
 keywords = ["crypto", "mac", "daa"]
 
 [dependencies]
-digest = { version = "0.10.7", features = ["mac"] }
+digest = { version = "0.10.3", features = ["mac"] }
 cipher = "0.4.2"
 
 [dev-dependencies]
 aes = "0.8"
 des = "0.8"
-digest = { version = "0.10.7", features = ["dev"] }
+digest = { version = "0.10.3", features = ["dev"] }
 hex-literal = "0.3"
 
 [features]

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["cryptography", "no-std"]
 exclude = ["tests/cavp_large.rs", "tests/data/cavp_aes128_large.blb"]
 
 [dependencies]
-digest = { version = "0.10.7", features = ["mac"] }
+digest = { version = "0.10.3", features = ["mac"] }
 cipher = "0.4.2"
 dbl = "0.3"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
+digest = { version = "0.10.3", features = ["dev"] }
 hex-literal = "0.3"
 aes = "0.8"
 des = "0.8"

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -13,13 +13,13 @@ keywords = ["crypto", "mac", "pmac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.10.7", features = ["mac"] }
+digest = { version = "0.10.3", features = ["mac"] }
 cipher = "0.4.2"
 dbl = "0.3"
 
 [dev-dependencies]
 aes = "0.8"
-digest = { version = "0.10.7", features = ["dev"] }
+digest = { version = "0.10.3", features = ["dev"] }
 
 [features]
 std = ["digest/std"]


### PR DESCRIPTION
Avoids bumping the patch version requirements on `digest` which occurred in #139