### PR TITLE
hmac: bump `digest` to v0.11.0-pre.3; MSRV 1.71

### DIFF
--- a/.github/workflows/hmac.yml
+++ b/.github/workflows/hmac.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4.1.1

--- a/hmac/Cargo.lock
+++ b/hmac/Cargo.lock
@@ -10,11 +10,11 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "72bc448e41b30773616b4f51a23f1a51634d41ce0d06a9bf6c3065ee85e227a1"
 dependencies = [
- "generic-array",
+ "crypto-common",
 ]
 
 [[package]]
@@ -34,19 +34,20 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "cc17eb697364b18256ec92675ebe6b7b153d2f1041e568d74533c5d0fc1ca162"
 dependencies = [
- "generic-array",
- "typenum",
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "eb3be3c52e023de5662dc05a32f747d09a1d6024fdd1f64b0850e373269efb43"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -55,37 +56,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "getrandom"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "typenum",
- "version_check",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "hex-literal"
-version = "0.2.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70693199b3cf4552f3fa720b54163927a3ebed2aef240efaf556033ab336a11"
-dependencies = [
- "hex-literal-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "hex-literal-impl"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59448fc2f82a5fb6907f78c3d69d843e82ff5b051923313cc4438cb0c7b745a8"
-dependencies = [
- "proc-macro-hack",
-]
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -96,32 +85,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.148"
+name = "hybrid-array"
+version = "0.2.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "dad20e1fc790e8dc3294de8d1936f6c25e6a498507506d7d4705d0242c0c7fda"
 dependencies = [
  "cfg-if",
  "digest",
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
+name = "rand_core"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "c14486028be4486a46aa8c4131ef865ec85b221c1e1327af76f10b6981e06850"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -130,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "de0628cd6fd8219612c2d71ad52ab8c2014a18cbdbedbde17de04d400df65997"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -141,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.10.2"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7fe6ed8a42cec360e070309427bb7959e102849b0dbaa7de19d5b9860bd536"
+checksum = "95fb02b2a927e059d2bf349eb26664c7ca663c980e069feb4782adb465c5c9e3"
 dependencies = [
  "digest",
 ]
@@ -161,7 +162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,26 +1,27 @@
 [package]
 name = "hmac"
-version = "0.12.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.13.0-pre"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 documentation = "https://docs.rs/hmac"
 repository = "https://github.com/RustCrypto/MACs"
 keywords = ["crypto", "mac", "hmac", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.71"
 
 [dependencies]
-digest = { version = "0.10.3", features = ["mac"] }
+digest = { version = "=0.11.0-pre.3", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.10", features = ["dev"] }
-md-5 = { version = "0.10", default-features = false }
-sha1 = { version = "0.10", default-features = false }
-sha2 = { version = "0.10", default-features = false }
-streebog = { version = "0.10", default-features = false }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
+md-5 = { version = "=0.11.0-pre.0", default-features = false }
+sha1 = { version = "=0.11.0-pre.0", default-features = false }
+sha2 = { version = "=0.11.0-pre.0", default-features = false }
+streebog = { version = "=0.11.0-pre.0", default-features = false }
+hex-literal = "0.4"
 
 [features]
 std = ["digest/std"]

--- a/hmac/README.md
+++ b/hmac/README.md
@@ -12,7 +12,7 @@ Pure Rust implementation of the [Hash-based Message Authentication Code (HMAC)][
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.71** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -44,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/hmac/badge.svg
 [docs-link]: https://docs.rs/hmac/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260044-MACs
 

--- a/hmac/src/lib.rs
+++ b/hmac/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```rust
 //! use sha2::Sha256;
-//! use hmac::{Hmac, Mac};
+//! use hmac::{Hmac, KeyInit, Mac};
 //! use hex_literal::hex;
 //!
 //! // Create alias for HMAC-SHA256
@@ -49,7 +49,7 @@
 //!
 //! ```rust
 //! # use sha2::Sha256;
-//! # use hmac::{Hmac, Mac};
+//! # use hmac::{Hmac, KeyInit, Mac};
 //! # use hex_literal::hex;
 //! # type HmacSha256 = Hmac<Sha256>;
 //! let mut mac = HmacSha256::new_from_slice(b"my secret and secure key")
@@ -84,8 +84,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
-    html_root_url = "https://docs.rs/hmac/0.12.1"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg"
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -95,7 +94,7 @@
 extern crate std;
 
 pub use digest;
-pub use digest::Mac;
+pub use digest::{KeyInit, Mac};
 
 use digest::{
     core_api::{Block, BlockSizeUser},

--- a/hmac/src/optim.rs
+++ b/hmac/src/optim.rs
@@ -3,13 +3,13 @@ use core::{fmt, slice};
 #[cfg(feature = "reset")]
 use digest::Reset;
 use digest::{
+    array::typenum::{IsLess, Le, NonZero, U256},
     block_buffer::Eager,
     core_api::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, CoreProxy, CoreWrapper,
         FixedOutputCore, OutputSizeUser, UpdateCore,
     },
     crypto_common::{Key, KeySizeUser},
-    generic_array::typenum::{IsLess, Le, NonZero, U256},
     HashMarker, InvalidLength, KeyInit, MacMarker, Output,
 };
 


### PR DESCRIPTION
This prerelease of `digest` notably includes a migration from `generic-array` to `hybrid-array`.

Bumps the crate version to v0.13.0-pre to denote this is a breaking change, however note there is not a crate release associated with this version bump.

The edition has also been bumped to 2021, and `hex-literal` has been upgraded to v0.4.