### PR TITLE
hmac: bump `digest` dependency to v0.11.0-pre.4

### DIFF
--- a/hmac/Cargo.lock
+++ b/hmac/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72bc448e41b30773616b4f51a23f1a51634d41ce0d06a9bf6c3065ee85e227a1"
+checksum = "0edadbde8e0243b49d434f9a23ec0590af201f400a34d7d51049284e4a77c568"
 dependencies = [
  "crypto-common",
 ]
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.3"
+version = "0.2.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc17eb697364b18256ec92675ebe6b7b153d2f1041e568d74533c5d0fc1ca162"
+checksum = "806e4e3731d44f1340b069551225b44c2056c105cad9e67f0c46266db8a3a6b9"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3be3c52e023de5662dc05a32f747d09a1d6024fdd1f64b0850e373269efb43"
+checksum = "b429fb535b92bad18c86f1d7ee7584a175c2810800c7ac5b75b9408b13981979"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -74,7 +74,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.0"
+version = "0.13.0-pre.1"
 dependencies = [
  "digest",
  "hex-literal",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-pre.8"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
+checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
 dependencies = [
  "typenum",
 ]
@@ -101,9 +101,9 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad20e1fc790e8dc3294de8d1936f6c25e6a498507506d7d4705d0242c0c7fda"
+checksum = "d16de5e3b92a3ecc566508a82dde68e28e5a1a91b1db13e1d243f2dc560ac90a"
 dependencies = [
  "cfg-if",
  "digest",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14486028be4486a46aa8c4131ef865ec85b221c1e1327af76f10b6981e06850"
+checksum = "731912b869ff1fb4c6432ad4737a5951d5388fbdda0417163a29638206935fe6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0628cd6fd8219612c2d71ad52ab8c2014a18cbdbedbde17de04d400df65997"
+checksum = "9daa731ca112bb569b34b41775363a461422813d8ed1ea6dba352eb58ec4e684"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fb02b2a927e059d2bf349eb26664c7ca663c980e069feb4782adb465c5c9e3"
+checksum = "9195128e99b61b19a1d847de3e60b8dc895e4a133ac1e3f94087f1f94ce434ba"
 dependencies = [
  "digest",
 ]

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.13.0-pre.0"
+version = "0.13.0-pre.1"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,14 +13,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.71"
 
 [dependencies]
-digest = { version = "=0.11.0-pre.3", features = ["mac"] }
+digest = { version = "=0.11.0-pre.4", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.3", features = ["dev"] }
-md-5 = { version = "=0.11.0-pre.0", default-features = false }
-sha1 = { version = "=0.11.0-pre.0", default-features = false }
-sha2 = { version = "=0.11.0-pre.0", default-features = false }
-streebog = { version = "=0.11.0-pre.0", default-features = false }
+digest = { version = "=0.11.0-pre.4", features = ["dev"] }
+md-5 = { version = "=0.11.0-pre.1", default-features = false }
+sha1 = { version = "=0.11.0-pre.1", default-features = false }
+sha2 = { version = "=0.11.0-pre.1", default-features = false }
+streebog = { version = "=0.11.0-pre.1", default-features = false }
 hex-literal = "0.4"
 
 [features]


### PR DESCRIPTION
Also cuts a v0.13.0-pre.1 release of `hmac`