### PR TITLE
hmac: bump `digest` to v0.11.0-pre.8

### DIFF
--- a/hmac/Cargo.lock
+++ b/hmac/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.4"
+version = "0.11.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edadbde8e0243b49d434f9a23ec0590af201f400a34d7d51049284e4a77c568"
+checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
 dependencies = [
  "crypto-common",
 ]
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.4"
+version = "0.2.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806e4e3731d44f1340b069551225b44c2056c105cad9e67f0c46266db8a3a6b9"
+checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.7"
+version = "0.11.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957713a19ffdda287c63772e607f848512f67ba948f17d8e42cb8d50fd98a786"
+checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -74,7 +74,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.2"
+version = "0.13.0-pre.3"
 dependencies = [
  "digest",
  "hex-literal",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
+checksum = "18e63b66aee2df5599ba69b17a48113dfc68d2e143ea387ef836509e433bbd7e"
 dependencies = [
  "typenum",
 ]
@@ -101,9 +101,9 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-pre.2"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8abbac3acc78149aba64dd60d8c147995f5eaab3f8943c0a9d9c1fa52de5d1"
+checksum = "649f2dc52b97a3d781ba9a36dad970f147d55920d17a27735f551b560024f3bf"
 dependencies = [
  "cfg-if",
  "digest",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.2"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301ed48dd873557d86a1843ebcdd511b628f13ec5401a0efa7007dc5a595eb1f"
+checksum = "3885de8cb916f223718c1ccd47a840b91f806333e76002dc5cb3862154b4fed3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.2"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18b939d4051b69874cbdb8f55de6a14ae44b357ccb94bdbd0a2122f8f875a46"
+checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.11.0-pre.2"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0849f719669df4f019cf2dc3fd219d9ea661662e68a6ee8726e2ad1164fc9843"
+checksum = "906aaaef0b6bfcf186c7aac662b06a11769e688744323aa6ff3b9f96a5c71c09"
 dependencies = [
  "digest",
 ]

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.13.0-pre.2"
+version = "0.13.0-pre.3"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,14 +13,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.72"
 
 [dependencies]
-digest = { version = "=0.11.0-pre.7", features = ["mac"] }
+digest = { version = "=0.11.0-pre.8", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.7", features = ["dev"] }
-md-5 = { version = "=0.11.0-pre.2", default-features = false }
-sha1 = { version = "=0.11.0-pre.2", default-features = false }
-sha2 = { version = "=0.11.0-pre.2", default-features = false }
-streebog = { version = "=0.11.0-pre.2", default-features = false }
+digest = { version = "=0.11.0-pre.8", features = ["dev"] }
+md-5 = { version = "=0.11.0-pre.3", default-features = false }
+sha1 = { version = "=0.11.0-pre.3", default-features = false }
+sha2 = { version = "=0.11.0-pre.3", default-features = false }
+streebog = { version = "=0.11.0-pre.3", default-features = false }
 hex-literal = "0.4"
 
 [features]


### PR DESCRIPTION
Also cuts a v0.13.0-pre.3 prerelease of `hmac`