### PR TITLE
cbc-mac+cmac+pmac: cut pre.1 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "cbc-mac"
-version = "0.2.0-pre"
+version = "0.2.0-pre.1"
 dependencies = [
  "aes",
  "cipher",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-pre"
+version = "0.8.0-pre.1"
 dependencies = [
  "aes",
  "cipher",
@@ -158,7 +158,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.3"
+version = "0.13.0-pre.4"
 dependencies = [
  "digest",
  "hex-literal",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "pmac"
-version = "0.8.0-pre"
+version = "0.8.0-pre.1"
 dependencies = [
  "aes",
  "cipher",

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbc-mac"
-version = "0.2.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0-pre.1"
 description = "Implementation of Cipher Block Chaining Message Authentication Code (CBC-MAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cbc-mac/src/lib.rs
+++ b/cbc-mac/src/lib.rs
@@ -27,8 +27,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
-    html_root_url = "https://docs.rs/cbc-mac/0.1.1"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.8.0-pre"
+version = "0.8.0-pre.1"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.8.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.8.0-pre.1"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pmac/src/lib.rs
+++ b/pmac/src/lib.rs
@@ -42,8 +42,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
-    html_root_url = "https://docs.rs/pmac/0.7.1"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg"
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
Cuts the following prereleases:

- `cbc-mac` v0.2.0-pre.1
- `cmac` v0.8.0-pre.1
- `pmac` v0.8.0-pre.1