### PR TITLE
chore(deps): bump digest pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,8 +67,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cipher"
 version = "0.5.0-pre.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276974d2acb7cf592603150941fc1ff6442acdeb1dc653ac2825928f4703c131"
+source = "git+https://github.com/RustCrypto/traits.git?branch=digest%2Fnewtype#f3d7a4fd41036494ee89bb3f282a6d01dfcf072a"
 dependencies = [
  "crypto-common",
  "inout",
@@ -101,8 +100,7 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.2.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170d71b5b14dec99db7739f6fc7d6ec2db80b78c3acb77db48392ccc3d8a9ea0"
+source = "git+https://github.com/RustCrypto/traits.git?branch=digest%2Fnewtype#f3d7a4fd41036494ee89bb3f282a6d01dfcf072a"
 dependencies = [
  "hybrid-array",
 ]
@@ -128,8 +126,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.11.0-pre.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c478574b20020306f98d61c8ca3322d762e1ff08117422ac6106438605ea516"
+source = "git+https://github.com/RustCrypto/traits.git?branch=digest%2Fnewtype#f3d7a4fd41036494ee89bb3f282a6d01dfcf072a"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -202,8 +199,7 @@ dependencies = [
 [[package]]
 name = "md-5"
 version = "0.11.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f97ce75b16c61e8ffe9363ca30092ff9da9daed3c7312296eef978c4ecb2d28"
+source = "git+https://github.com/RustCrypto/hashes.git?branch=newtype#ada01159b7499ab6d99f11f7f90cfd18c6e157e5"
 dependencies = [
  "cfg-if",
  "digest",
@@ -233,8 +229,7 @@ dependencies = [
 [[package]]
 name = "sha1"
 version = "0.11.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f44e40722caefdd99383c25d3ae52a1094a1951215ae76f68837ece4e7f566"
+source = "git+https://github.com/RustCrypto/hashes.git?branch=newtype#ada01159b7499ab6d99f11f7f90cfd18c6e157e5"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -244,8 +239,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.11.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b4241d1a56954dce82cecda5c8e9c794eef6f53abe5e5216bac0a0ea71ffa7"
+source = "git+https://github.com/RustCrypto/hashes.git?branch=newtype#ada01159b7499ab6d99f11f7f90cfd18c6e157e5"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -255,8 +249,7 @@ dependencies = [
 [[package]]
 name = "streebog"
 version = "0.11.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a275f3837c892b08e1e992cf3ef597aa2aecea6d985a6db2035b367673cfe1"
+source = "git+https://github.com/RustCrypto/hashes.git?branch=newtype#ada01159b7499ab6d99f11f7f90cfd18c6e157e5"
 dependencies = [
  "digest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,13 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+crypto-common = { git = "https://github.com/RustCrypto/traits.git", branch = "digest/newtype" }
+cipher        = { git = "https://github.com/RustCrypto/traits.git", branch = "digest/newtype" }
+digest        = { git = "https://github.com/RustCrypto/traits.git", branch = "digest/newtype" }
+
+streebog = { git = "https://github.com/RustCrypto/hashes.git", branch = "newtype" }
+md-5     = { git = "https://github.com/RustCrypto/hashes.git", branch = "newtype" }
+sha1     = { git = "https://github.com/RustCrypto/hashes.git", branch = "newtype" }
+sha2     = { git = "https://github.com/RustCrypto/hashes.git", branch = "newtype" }

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -22,7 +22,6 @@ digest = { version = "=0.11.0-pre.10", features = ["dev"] }
 hex-literal = "1"
 
 [features]
-std = ["digest/std"]
 zeroize = ["cipher/zeroize"]
 
 [package.metadata.docs.rs]

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -23,7 +23,6 @@ aes = "0.9.0-pre.3"
 des = "0.9.0-pre.3"
 
 [features]
-std = ["digest/std"]
 zeroize = ["cipher/zeroize"]
 
 [package.metadata.docs.rs]

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -28,7 +28,6 @@ kuznyechik = "0.9.0-pre.3"
 magma = "0.10.0-pre.3"
 
 [features]
-std = ["digest/std"]
 zeroize = ["cipher/zeroize"]
 
 [package.metadata.docs.rs]

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -24,7 +24,7 @@ streebog = { version = "=0.11.0-pre.5", default-features = false }
 hex-literal = "1"
 
 [features]
-std = ["digest/std"]
+std = []
 reset = [] # Enable ability to reset HMAC instances
 
 [package.metadata.docs.rs]

--- a/hmac/src/optim.rs
+++ b/hmac/src/optim.rs
@@ -4,8 +4,8 @@ use digest::{
     HashMarker, InvalidLength, KeyInit, MacMarker, Output,
     block_buffer::Eager,
     core_api::{
-        AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, CoreWrapper, FixedOutputCore,
-        OutputSizeUser, UpdateCore,
+        AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, CoreProxy, CoreWrapper,
+        FixedOutputCore, OutputSizeUser, UpdateCore,
     },
     crypto_common::{Key, KeySizeUser},
 };
@@ -24,8 +24,9 @@ pub trait EagerHash {
         + Clone;
 }
 
-impl<C> EagerHash for CoreWrapper<C>
+impl<D, C> EagerHash for D
 where
+    D: CoreProxy<Core = C>,
     C: HashMarker
         + UpdateCore
         + FixedOutputCore

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -22,7 +22,7 @@ aes = "0.9.0-pre.3"
 digest = { version = "=0.11.0-pre.10", features = ["dev"] }
 
 [features]
-std = ["digest/std"]
+std = []
 zeroize = ["cipher/zeroize"]
 
 [package.metadata.docs.rs]

--- a/retail-mac/Cargo.toml
+++ b/retail-mac/Cargo.toml
@@ -23,7 +23,6 @@ aes = "0.9.0-pre.2"
 des = "0.9.0-pre.2"
 
 [features]
-std = ["digest/std"]
 zeroize = ["cipher/zeroize"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
digest doesn't provide `std` feature anymore

Depends; 
 - https://github.com/RustCrypto/traits/pull/1799 
 - https://github.com/RustCrypto/hashes/pull/678