### PR TITLE
hmac: remove explicit `--cfg docsrs`

### DIFF
--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -28,4 +28,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
The flag is passed automatically by docs.rs.