### PR TITLE
Bump `digest` dependency to v0.11.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,8 +101,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+version = "0.2.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
  "hybrid-array",
 ]
@@ -127,8 +128,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.10"
-source = "git+https://github.com/RustCrypto/traits#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460dd7f37e4950526b54a5a6b1f41b6c8e763c58eb9a8fc8fc05ba5c2f44ca7b"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -201,8 +203,9 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1788e007bfe04177a520c827ef99f436b1ea79719d5c5f049279dfe85a7b28"
 dependencies = [
  "cfg-if",
  "digest",
@@ -231,8 +234,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -241,8 +245,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -251,8 +256,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd1781d17a54baf1c29e23aee9d49ad89accf4551c80ed1b7edd1659a2c6dbb"
 dependencies = [
  "digest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-# https://github.com/RustCrypto/traits/pull/1787
-# https://github.com/RustCrypto/traits/pull/1799
-digest = { git = "https://github.com/RustCrypto/traits" }
-crypto-common = { git = "https://github.com/RustCrypto/traits" }
-
-# https://github.com/RustCrypto/hashes/pull/678
-streebog = { git = "https://github.com/RustCrypto/hashes" }
-sha1 = { git = "https://github.com/RustCrypto/hashes" }
-sha2 = { git = "https://github.com/RustCrypto/hashes" }
-md-5 = { git = "https://github.com/RustCrypto/hashes" }

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 belt-block = "0.2.0-pre.3"
 cipher = "=0.5.0-pre.8"
-digest = { version = "=0.11.0-pre.10", features = ["mac"] }
+digest = { version = "0.11.0-rc.0", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "mac", "daa"]
 
 [dependencies]
 cipher = "=0.5.0-pre.8"
-digest = { version = "=0.11.0-pre.10", features = ["mac"] }
+digest = { version = "0.11.0-rc.0", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-pre.3"

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -15,11 +15,11 @@ exclude = ["tests/cavp_large.rs", "tests/data/cavp_aes128_large.blb"]
 
 [dependencies]
 cipher = "=0.5.0-pre.8"
-digest = { version = "=0.11.0-pre.10", features = ["mac"] }
+digest = { version = "0.11.0-rc.0", features = ["mac"] }
 dbl = "0.4.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-pre.3"

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -13,14 +13,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["mac"] }
+digest = { version = "0.11.0-rc.0", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
-md-5 = { version = "=0.11.0-pre.5", default-features = false }
-sha1 = { version = "=0.11.0-pre.5", default-features = false }
-sha2 = { version = "=0.11.0-pre.5", default-features = false }
-streebog = { version = "=0.11.0-pre.5", default-features = false }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
+md-5 = { version = "0.11.0-rc.0", default-features = false }
+sha1 = { version = "0.11.0-rc.0", default-features = false }
+sha2 = { version = "0.11.0-rc.0", default-features = false }
+streebog = { version = "0.11.0-rc.0", default-features = false }
 hex-literal = "1"
 
 [features]

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cipher = "=0.5.0-pre.8"
-digest = { version = "=0.11.0-pre.10", features = ["mac"] }
+digest = { version = "0.11.0-rc.0", features = ["mac"] }
 dbl = "0.4.0-rc.0"
 
 [dev-dependencies]
 aes = "0.9.0-pre.3"
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/retail-mac/Cargo.toml
+++ b/retail-mac/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "mac"]
 
 [dependencies]
 cipher = "=0.5.0-pre.8"
-digest = { version = "=0.11.0-pre.10", features = ["mac"] }
+digest = { version = "0.11.0-rc.0", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-pre.2"


### PR DESCRIPTION
NOTE: no releases with this PR.

I'll open a separate one for `hmac`, but for the others we should probably cut another `cipher` release first