### PR TITLE
Bump `cipher` v0.5.0-rc.1; `digest` v0.11.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,8 +40,9 @@ checksum = "4a859067dcb257cb2ae028cb821399b55140b76fb8b2a360e052fe109019db43"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -66,8 +67,9 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.5.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -100,8 +102,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.3"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.2.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
 dependencies = [
  "hybrid-array",
 ]
@@ -125,8 +128,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.11.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4aae35a0fcbe22ff1be50fe96df72002d5a4a6fb4aae9193cf2da0daa36da2"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -165,8 +169,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.5"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.2.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
 dependencies = [
  "hybrid-array",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,4 @@ opt-level = 2
 
 [patch.crates-io]
 # https://github.com/RustCrypto/utils/pull/1208
-block-buffer = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/traits/pull/1976
-cipher = { git = "https://github.com/RustCrypto/traits" }
-# https://github.com/RustCrypto/traits/pull/1976
-crypto-common = { git = "https://github.com/RustCrypto/traits" }
-# https://github.com/RustCrypto/utils/pull/1208
 dbl = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/traits/pull/1976
-digest = { git = "https://github.com/RustCrypto/traits" }
-# https://github.com/RustCrypto/utils/pull/1208
-inout = { git = "https://github.com/RustCrypto/utils" }

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 belt-block = "0.2.0-pre.3"
-cipher = "0.5.0-rc.0"
-digest = { version = "0.11.0-rc.0", features = ["mac"] }
+cipher = "0.5.0-rc.1"
+digest = { version = "0.11.0-rc.1", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/RustCrypto/MACs"
 keywords = ["crypto", "mac", "daa"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
-digest = { version = "0.11.0-rc.0", features = ["mac"] }
+cipher = "0.5.0-rc.1"
+digest = { version = "0.11.0-rc.1", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-rc.0"

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["cryptography", "no-std"]
 exclude = ["tests/cavp_large.rs", "tests/data/cavp_aes128_large.blb"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
-digest = { version = "0.11.0-rc.0", features = ["mac"] }
+cipher = "0.5.0-rc.1"
+digest = { version = "0.11.0-rc.1", features = ["mac"] }
 dbl = "0.5.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-rc.0"

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.0", features = ["mac"] }
+digest = { version = "0.11.0-rc.1", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 md-5 = { version = "0.11.0-rc.0", default-features = false }
 sha1 = { version = "0.11.0-rc.0", default-features = false }
 sha2 = { version = "0.11.0-rc.0", default-features = false }

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -13,13 +13,13 @@ keywords = ["crypto", "mac", "pmac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
-digest = { version = "0.11.0-rc.0", features = ["mac"] }
+cipher = "0.5.0-rc.1"
+digest = { version = "0.11.0-rc.1", features = ["mac"] }
 dbl = "0.5.0-pre"
 
 [dev-dependencies]
 aes = "0.9.0-rc.0"
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/retail-mac/Cargo.toml
+++ b/retail-mac/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/RustCrypto/MACs"
 keywords = ["crypto", "mac"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
-digest = { version = "0.11.0-rc.0", features = ["mac"] }
+cipher = "0.5.0-rc.1"
+digest = { version = "0.11.0-rc.1", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-rc.0"


### PR DESCRIPTION
These notably support `hybrid-array` v0.4