### PR TITLE
Bump cipher and hash dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4838e4ad37bb032dea137f441d5f71c16c26c068af512e64c5bc13a88cdfc7"
+checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8025983b9f9f242e94d459a57b81c571e92e4e1717ca57d092d8a69fc539efa1"
+checksum = "3f51594a70805988feb1c85495ddec0c2052e4fbe59d9c0bb7f94bfc164f4f90"
 dependencies = [
  "cipher",
 ]
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074a7089016bcddb3b8da42f663296a885f8a31ec57a7b795a92b711999ff5aa"
+checksum = "e39eb5f1f53d41c9341e559c72a732db17619643679116d56ca0af8b34cb8b26"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -194,18 +194,18 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "magma"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6704a51253dc03b397da9121342836759922371190e5755ccfb21c4db9cef4"
+checksum = "47c60b0343c651857c53e0072315831622d550efeb663a589bbd3fdd83073da0"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1788e007bfe04177a520c827ef99f436b1ea79719d5c5f049279dfe85a7b28"
+checksum = "f9ec86664728010f574d67ef01aec964e6f1299241a3402857c1a8a390a62478"
 dependencies = [
  "cfg-if",
  "digest",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
+checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
+checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd1781d17a54baf1c29e23aee9d49ad89accf4551c80ed1b7edd1659a2c6dbb"
+checksum = "7032930cdbb2ca75cafb6b91674728bd923d9a47941ac95183337c53445399ff"
 dependencies = [
  "digest",
 ]

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "mac", "belt-mac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-belt-block = "0.2.0-pre.3"
+belt-block = "0.2.0-pre.4"
 cipher = "0.5.0-rc.1"
 digest = { version = "0.11.0-rc.1", features = ["mac"] }
 

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -19,8 +19,8 @@ digest = { version = "0.11.0-rc.1", features = ["mac"] }
 digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
-aes = "0.9.0-rc.0"
-des = "0.9.0-rc.0"
+aes = "0.9.0-rc.1"
+des = "0.9.0-rc.1"
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -22,10 +22,10 @@ dbl = "0.5.0-pre"
 digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
-aes = "0.9.0-rc.0"
-des = "0.9.0-rc.0"
-kuznyechik = "0.9.0-rc.0"
-magma = "0.10.0-rc.0"
+aes = "0.9.0-rc.1"
+des = "0.9.0-rc.1"
+kuznyechik = "0.9.0-rc.1"
+magma = "0.10.0-rc.1"
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -17,10 +17,10 @@ digest = { version = "0.11.0-rc.1", features = ["mac"] }
 
 [dev-dependencies]
 digest = { version = "0.11.0-rc.1", features = ["dev"] }
-md-5 = { version = "0.11.0-rc.0", default-features = false }
-sha1 = { version = "0.11.0-rc.0", default-features = false }
-sha2 = { version = "0.11.0-rc.0", default-features = false }
-streebog = { version = "0.11.0-rc.0", default-features = false }
+md-5 = { version = "0.11.0-rc.2", default-features = false }
+sha1 = { version = "0.11.0-rc.2", default-features = false }
+sha2 = { version = "0.11.0-rc.2", default-features = false }
+streebog = { version = "0.11.0-rc.2", default-features = false }
 hex-literal = "1"
 
 [features]

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -18,7 +18,7 @@ digest = { version = "0.11.0-rc.1", features = ["mac"] }
 dbl = "0.5.0-pre"
 
 [dev-dependencies]
-aes = "0.9.0-rc.0"
+aes = "0.9.0-rc.1"
 digest = { version = "0.11.0-rc.1", features = ["dev"] }
 
 [features]

--- a/retail-mac/Cargo.toml
+++ b/retail-mac/Cargo.toml
@@ -19,8 +19,8 @@ digest = { version = "0.11.0-rc.1", features = ["mac"] }
 digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
-aes = "0.9.0-rc.0"
-des = "0.9.0-rc.0"
+aes = "0.9.0-rc.1"
+des = "0.9.0-rc.1"
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]


### PR DESCRIPTION
Uses `hybrid-array` v0.4 compatible versions