### PR TITLE
Cut rc.3 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
+checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "cbc-mac"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.3"
 dependencies = [
  "aes",
  "cipher",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.3"
 dependencies = [
  "aes",
  "cipher",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f51594a70805988feb1c85495ddec0c2052e4fbe59d9c0bb7f94bfc164f4f90"
+checksum = "512ca722eff02fa73c43e5136f440c46f861d41f9dd7761c1f2817a5ca5d9ad7"
 dependencies = [
  "cipher",
 ]
@@ -148,7 +148,7 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 dependencies = [
  "digest",
  "hex-literal",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39eb5f1f53d41c9341e559c72a732db17619643679116d56ca0af8b34cb8b26"
+checksum = "f692f9023c6a17c2646c2751b169c9136d517718505531f2af18bd2b69780f13"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -195,18 +195,18 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "magma"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c60b0343c651857c53e0072315831622d550efeb663a589bbd3fdd83073da0"
+checksum = "0a050323412d2adf0ad86903bc188640b1abba7da0ab6450e035437fce7596d7"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ec86664728010f574d67ef01aec964e6f1299241a3402857c1a8a390a62478"
+checksum = "64dd2c9099caf8e29b629305199dddb1c6d981562b62c089afea54b0b4b5c333"
 dependencies = [
  "cfg-if",
  "digest",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "pmac"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.3"
 dependencies = [
  "aes",
  "cipher",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
+checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7032930cdbb2ca75cafb6b91674728bd923d9a47941ac95183337c53445399ff"
+checksum = "4b24f3259853f4857159f8dfefc4e3500b37cf91e497944b99d9434371d4db05"
 dependencies = [
  "digest",
 ]

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "mac", "belt-mac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-belt-block = "0.2.0-pre.4"
+belt-block = "0.2.0-rc.1"
 cipher = "0.5.0-rc.2"
 digest = { version = "0.11.0-rc.4", features = ["mac"] }
 

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbc-mac"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.3"
 description = "Implementation of Cipher Block Chaining Message Authentication Code (CBC-MAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -19,8 +19,8 @@ digest = { version = "0.11.0-rc.4", features = ["mac"] }
 digest = { version = "0.11.0-rc.4", features = ["dev"] }
 hex-literal = "1"
 
-aes = "0.9.0-rc.1"
-des = "0.9.0-rc.1"
+aes = "0.9.0-rc.2"
+des = "0.9.0-rc.2"
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.3"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -22,10 +22,10 @@ dbl = "0.5"
 digest = { version = "0.11.0-rc.4", features = ["dev"] }
 hex-literal = "1"
 
-aes = "0.9.0-rc.1"
-des = "0.9.0-rc.1"
-kuznyechik = "0.9.0-rc.1"
-magma = "0.10.0-rc.1"
+aes = "0.9.0-rc.2"
+des = "0.9.0-rc.2"
+kuznyechik = "0.9.0-rc.2"
+magma = "0.10.0-rc.2"
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -17,10 +17,10 @@ digest = { version = "0.11.0-rc.4", features = ["mac"] }
 
 [dev-dependencies]
 digest = { version = "0.11.0-rc.4", features = ["dev"] }
-md-5 = { version = "0.11.0-rc.2", default-features = false }
-sha1 = { version = "0.11.0-rc.2", default-features = false }
-sha2 = { version = "0.11.0-rc.2", default-features = false }
-streebog = { version = "0.11.0-rc.2", default-features = false }
+md-5 = { version = "0.11.0-rc.3", default-features = false }
+sha1 = { version = "0.11.0-rc.3", default-features = false }
+sha2 = { version = "0.11.0-rc.3", default-features = false }
+streebog = { version = "0.11.0-rc.3", default-features = false }
 hex-literal = "1"
 
 [features]

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.3"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ digest = { version = "0.11.0-rc.4", features = ["mac"] }
 dbl = "0.5"
 
 [dev-dependencies]
-aes = "0.9.0-rc.1"
+aes = "0.9.0-rc.2"
 digest = { version = "0.11.0-rc.4", features = ["dev"] }
 
 [features]


### PR DESCRIPTION
Releases the following:
- `cbc-mac` v0.2.0-rc.3
- `cmac` v0.8.0-rc.3
- `hmac` v0.13.0-rc.3
- `pmac` v0.8.0-rc.3