### PR TITLE
Bump `cipher` and `digest` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "89af0b093cc13baa4e51e64e65ec2422f7e73aea0e612e5ad3872986671622f1"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
+checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -67,9 +67,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
+checksum = "98d708bac5451350d56398433b19a7889022fa9187df1a769c0edbc3b2c03167"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
+checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
 dependencies = [
  "blobby",
  "block-buffer",

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 belt-block = "0.2.0-rc.1"
-cipher = "0.5.0-rc.2"
-digest = { version = "0.11.0-rc.4", features = ["mac"] }
+cipher = "0.5.0-rc.3"
+digest = { version = "0.11.0-rc.5", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.4", features = ["dev"] }
+digest = { version = "0.11.0-rc.5", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/RustCrypto/MACs"
 keywords = ["crypto", "mac", "daa"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
-digest = { version = "0.11.0-rc.4", features = ["mac"] }
+cipher = "0.5.0-rc.3"
+digest = { version = "0.11.0-rc.5", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.4", features = ["dev"] }
+digest = { version = "0.11.0-rc.5", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-rc.2"

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["cryptography", "no-std"]
 exclude = ["tests/cavp_large.rs", "tests/data/cavp_aes128_large.blb"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
-digest = { version = "0.11.0-rc.4", features = ["mac"] }
+cipher = "0.5.0-rc.3"
+digest = { version = "0.11.0-rc.5", features = ["mac"] }
 dbl = "0.5"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.4", features = ["dev"] }
+digest = { version = "0.11.0-rc.5", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-rc.2"

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.4", features = ["mac"] }
+digest = { version = "0.11.0-rc.5", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.4", features = ["dev"] }
+digest = { version = "0.11.0-rc.5", features = ["dev"] }
 md-5 = { version = "0.11.0-rc.3", default-features = false }
 sha1 = { version = "0.11.0-rc.3", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -13,13 +13,13 @@ keywords = ["crypto", "mac", "pmac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
-digest = { version = "0.11.0-rc.4", features = ["mac"] }
+cipher = "0.5.0-rc.3"
+digest = { version = "0.11.0-rc.5", features = ["mac"] }
 dbl = "0.5"
 
 [dev-dependencies]
 aes = "0.9.0-rc.2"
-digest = { version = "0.11.0-rc.4", features = ["dev"] }
+digest = { version = "0.11.0-rc.5", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/retail-mac/Cargo.toml
+++ b/retail-mac/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/RustCrypto/MACs"
 keywords = ["crypto", "mac"]
 
 [dependencies]
-cipher = "0.5.0-rc.2"
-digest = { version = "0.11.0-rc.4", features = ["mac"] }
+cipher = "0.5.0-rc.3"
+digest = { version = "0.11.0-rc.5", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.4", features = ["dev"] }
+digest = { version = "0.11.0-rc.5", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-rc.1"


### PR DESCRIPTION
Bumps these dependencies to the following versions:

- `cipher` v0.5.0-rc.3
- `digest` v0.11.0-rc.5