### PR TITLE
Bump `digest` to v0.11.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.8"
+version = "0.11.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1408b7a9f59a7b933faff3e9e7fc15a05a524effd3b3d1601156944c8077f"
+checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
 dependencies = [
  "blobby",
  "block-buffer",

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 belt-block = "0.2.0-rc.1"
 cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.8", features = ["mac"] }
+digest = { version = "0.11.0-rc.9", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.8", features = ["dev"] }
+digest = { version = "0.11.0-rc.9", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/belt-mac/src/block_api.rs
+++ b/belt-mac/src/block_api.rs
@@ -8,7 +8,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, FixedOutputCore, Lazy,
         UpdateCore,
     },
-    crypto_common::{BlockSizes, InnerInit, InnerUser},
+    common::{BlockSizes, InnerInit, InnerUser},
 };
 
 #[cfg(feature = "zeroize")]

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "mac", "daa"]
 
 [dependencies]
 cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.8", features = ["mac"] }
+digest = { version = "0.11.0-rc.9", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.8", features = ["dev"] }
+digest = { version = "0.11.0-rc.9", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-rc.2"

--- a/cbc-mac/src/block_api.rs
+++ b/cbc-mac/src/block_api.rs
@@ -7,7 +7,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         UpdateCore,
     },
-    crypto_common::{BlockSizes, InnerInit, InnerUser},
+    common::{BlockSizes, InnerInit, InnerUser},
 };
 
 #[cfg(feature = "zeroize")]

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -15,11 +15,11 @@ exclude = ["tests/cavp_large.rs", "tests/data/cavp_aes128_large.blb"]
 
 [dependencies]
 cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.8", features = ["mac"] }
+digest = { version = "0.11.0-rc.9", features = ["mac"] }
 dbl = "0.5"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.8", features = ["dev"] }
+digest = { version = "0.11.0-rc.9", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-rc.2"

--- a/cmac/src/block_api.rs
+++ b/cmac/src/block_api.rs
@@ -8,7 +8,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, FixedOutputCore, Lazy,
         UpdateCore,
     },
-    crypto_common::{BlockSizes, InnerInit, InnerUser},
+    common::{BlockSizes, InnerInit, InnerUser},
 };
 
 #[cfg(feature = "zeroize")]

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.8", features = ["mac"] }
+digest = { version = "0.11.0-rc.9", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.8", features = ["dev"] }
+digest = { version = "0.11.0-rc.9", features = ["dev"] }
 md-5 = { version = "0.11.0-rc.3", default-features = false }
 sha1 = { version = "0.11.0-rc.3", default-features = false }
 sha2 = { version = "0.11.0-rc.3", default-features = false }

--- a/hmac/src/block_api.rs
+++ b/hmac/src/block_api.rs
@@ -7,7 +7,7 @@ use digest::{
         OutputSizeUser, UpdateCore,
     },
     block_buffer::Eager,
-    crypto_common::{Key, KeySizeUser},
+    common::{Key, KeySizeUser},
 };
 
 /// Generic core HMAC instance, which operates over blocks.

--- a/hmac/src/simple.rs
+++ b/hmac/src/simple.rs
@@ -2,7 +2,7 @@ use crate::utils::{IPAD, OPAD, get_der_key};
 use core::fmt;
 use digest::{
     Digest, FixedOutput, KeyInit, MacMarker, Output, OutputSizeUser, Update,
-    crypto_common::{Block, BlockSizeUser, InvalidLength, Key, KeySizeUser},
+    common::{Block, BlockSizeUser, InvalidLength, Key, KeySizeUser},
 };
 
 /// Simplified HMAC instance able to operate over hash functions

--- a/hmac/src/simple_reset.rs
+++ b/hmac/src/simple_reset.rs
@@ -2,7 +2,7 @@ use crate::utils::{IPAD, OPAD, get_der_key};
 use core::fmt;
 use digest::{
     Digest, FixedOutput, KeyInit, MacMarker, Output, OutputSizeUser, Update,
-    crypto_common::{Block, BlockSizeUser, InvalidLength, Key, KeySizeUser},
+    common::{Block, BlockSizeUser, InvalidLength, Key, KeySizeUser},
 };
 use digest::{FixedOutputReset, Reset};
 

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.8", features = ["mac"] }
+digest = { version = "0.11.0-rc.9", features = ["mac"] }
 dbl = "0.5"
 
 [dev-dependencies]
 aes = "0.9.0-rc.2"
-digest = { version = "0.11.0-rc.8", features = ["dev"] }
+digest = { version = "0.11.0-rc.9", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/pmac/src/block_api.rs
+++ b/pmac/src/block_api.rs
@@ -8,7 +8,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, FixedOutputCore, Lazy,
         UpdateCore,
     },
-    crypto_common::{InnerInit, InnerUser},
+    common::{InnerInit, InnerUser},
     typenum::Unsigned,
 };
 

--- a/retail-mac/Cargo.toml
+++ b/retail-mac/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "mac"]
 
 [dependencies]
 cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.8", features = ["mac"] }
+digest = { version = "0.11.0-rc.9", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.8", features = ["dev"] }
+digest = { version = "0.11.0-rc.9", features = ["dev"] }
 hex-literal = "1"
 
 aes = "0.9.0-rc.1"

--- a/retail-mac/src/block_api.rs
+++ b/retail-mac/src/block_api.rs
@@ -10,7 +10,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         UpdateCore,
     },
-    crypto_common::BlockSizes,
+    common::BlockSizes,
     typenum::{Prod, U2},
 };
 


### PR DESCRIPTION
Uses the new `digest::common` re-export of `crypto-common`