### PR TITLE
Bump `cipher` to v0.5.0-rc.8; `digest` to v0.11.0-rc.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,20 +4,20 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
+checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d9cc93a6506887eed92e4e9459c13469eee4ef2b2af305a182ebf53e4d6a3"
+checksum = "0e3b1e9d1ad19c345095575076767febd525013fc5782276a21069901815ea45"
 dependencies = [
  "cipher",
 ]
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "cbc-mac"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 dependencies = [
  "aes",
  "cipher",
@@ -67,9 +67,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.6"
+version = "0.5.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba4d87abf4032a6d927f84b71af5086128a3349b929b4501c51a0fe0981a937"
+checksum = "9002c8edb9b1e21938663da3489c9c4403bba2393997fb2ecbd401386c0e71dc"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 dependencies = [
  "aes",
  "cipher",
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a8c0210fa48ba3ea04ac1e9c6e72ae66009db3b1f1745635d4ff2e58eaadd0"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "hybrid-array",
 ]
@@ -120,18 +126,18 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512ca722eff02fa73c43e5136f440c46f861d41f9dd7761c1f2817a5ca5d9ad7"
+checksum = "3214053e68a813b9c06ef61075c844f3a1cdeb307d8998ea8555c063caa52fa9"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+checksum = "02b42f1d9edf5207c137646b568a0168ca0ec25b7f9eaf7f9961da51a3d91cea"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -148,7 +154,7 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 dependencies = [
  "digest",
  "hex-literal",
@@ -179,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f692f9023c6a17c2646c2751b169c9136d517718505531f2af18bd2b69780f13"
+checksum = "1845d0271ee188d9eddbb2b027738da1e492fe5622d6f5353aea2e1bd40a62ff"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -195,18 +201,18 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "magma"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a050323412d2adf0ad86903bc188640b1abba7da0ab6450e035437fce7596d7"
+checksum = "287314ef5d338202e7be522fbbae35cad5d1dff1b8cb079a395eec3a9e31104a"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340c5c3970c137330f5289dc52a6f6c24db6d6839b6121efdeeb120061c30313"
+checksum = "59e715bb6f273068fc89403d6c4f5eeb83708c62b74c8d43e3e8772ca73a6288"
 dependencies = [
  "cfg-if",
  "digest",
@@ -214,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "pmac"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 dependencies = [
  "aes",
  "cipher",
@@ -224,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "retail-mac"
-version = "0.1.0-pre.0"
+version = "0.1.0-pre.1"
 dependencies = [
  "aes",
  "cipher",
@@ -235,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c777f0a122a53fddb0beb6e706771197000b8eb5c9f42b5b850f450ef48c788"
+checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -246,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -257,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a06ec57c92c6db98fc783bf712353fce33bf13f93104eb8bc9b2700e90526b"
+checksum = "8f02c29e9fbd46b3493c2d1b8038d738480a56d25edc0ec0acc27f796a125a89"
 dependencies = [
  "digest",
 ]

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["crypto", "mac", "belt-mac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-belt-block = "0.2.0-rc.1"
-cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.9", features = ["mac"] }
+belt-block = "0.2.0-rc.3"
+cipher = "0.5.0-rc.8"
+digest = { version = "0.11.0-rc.11", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbc-mac"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 description = "Implementation of Cipher Block Chaining Message Authentication Code (CBC-MAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,15 +12,15 @@ repository = "https://github.com/RustCrypto/MACs"
 keywords = ["crypto", "mac", "daa"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.9", features = ["mac"] }
+cipher = "0.5.0-rc.8"
+digest = { version = "0.11.0-rc.11", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 
-aes = "0.9.0-rc.2"
-des = "0.9.0-rc.2"
+aes = "0.9.0-rc.4"
+des = "0.9.0-rc.3"
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -14,18 +14,18 @@ categories = ["cryptography", "no-std"]
 exclude = ["tests/cavp_large.rs", "tests/data/cavp_aes128_large.blb"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.9", features = ["mac"] }
+cipher = "0.5.0-rc.8"
+digest = { version = "0.11.0-rc.11", features = ["mac"] }
 dbl = "0.5"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 
-aes = "0.9.0-rc.2"
-des = "0.9.0-rc.2"
-kuznyechik = "0.9.0-rc.2"
-magma = "0.10.0-rc.2"
+aes = "0.9.0-rc.4"
+des = "0.9.0-rc.3"
+kuznyechik = "0.9.0-rc.3"
+magma = "0.10.0-rc.3"
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/hmac/Cargo.toml
+++ b/hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmac"
-version = "0.13.0-rc.4"
+version = "0.13.0-rc.5"
 description = "Generic implementation of Hash-based Message Authentication Code (HMAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,14 +13,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = { version = "0.11.0-rc.9", features = ["mac"] }
+digest = { version = "0.11.0-rc.11", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
-md-5 = { version = "0.11.0-rc.4", default-features = false }
-sha1 = { version = "0.11.0-rc.4", default-features = false }
-sha2 = { version = "0.11.0-rc.4", default-features = false }
-streebog = { version = "0.11.0-rc.4", default-features = false }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
+md-5 = { version = "0.11.0-rc.5", default-features = false }
+sha1 = { version = "0.11.0-rc.5", default-features = false }
+sha2 = { version = "0.11.0-rc.5", default-features = false }
+streebog = { version = "0.11.0-rc.5", default-features = false }
 hex-literal = "1"
 
 [features]

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,13 +13,13 @@ keywords = ["crypto", "mac", "pmac"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.9", features = ["mac"] }
+cipher = "0.5.0-rc.8"
+digest = { version = "0.11.0-rc.11", features = ["mac"] }
 dbl = "0.5"
 
 [dev-dependencies]
-aes = "0.9.0-rc.2"
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+aes = "0.9.0-rc.4"
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]

--- a/retail-mac/Cargo.toml
+++ b/retail-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retail-mac"
-version = "0.1.0-pre.0"
+version = "0.1.0-pre.1"
 description = "Implementation of Retail Message Authentication Code (Retail MAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -12,15 +12,15 @@ repository = "https://github.com/RustCrypto/MACs"
 keywords = ["crypto", "mac"]
 
 [dependencies]
-cipher = "0.5.0-rc.6"
-digest = { version = "0.11.0-rc.9", features = ["mac"] }
+cipher = "0.5.0-rc.8"
+digest = { version = "0.11.0-rc.11", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 
-aes = "0.9.0-rc.1"
-des = "0.9.0-rc.1"
+aes = "0.9.0-rc.4"
+des = "0.9.0-rc.3"
 
 [features]
 zeroize = ["cipher/zeroize", "digest/zeroize"]


### PR DESCRIPTION
Also cuts the following releases:
- `cbc-mac` v0.2.0-rc.4
- `cmac` v0.8.0-rc.4
- `hmac` v0.13.0-rc.5
- `pmac` v0.8.0-rc.4
- `retail-mac` v0.1.0-pre.1