### PR TITLE
Relax `Clone` bounds

### DIFF
--- a/belt-mac/src/block_api.rs
+++ b/belt-mac/src/block_api.rs
@@ -1,4 +1,3 @@
-use belt_block::BeltBlock;
 use cipher::{BlockCipherEncBackend, BlockCipherEncClosure, BlockCipherEncrypt};
 use core::fmt;
 use digest::{
@@ -17,9 +16,9 @@ use digest::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Generic core BeltMac instance, which operates over blocks.
 #[derive(Clone)]
-pub struct BeltMacCore<C = BeltBlock>
+pub struct BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     cipher: C,
     state: Block<C>,
@@ -28,30 +27,30 @@ where
 
 impl<C> BlockSizeUser for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     type BlockSize = C::BlockSize;
 }
 
 impl<C> OutputSizeUser for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     type OutputSize = C::BlockSize;
 }
 
 impl<C> InnerUser for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     type Inner = C;
 }
 
-impl<C> MacMarker for BeltMacCore<C> where C: BlockCipherEncrypt + SmallBlockSizeUser + Clone {}
+impl<C> MacMarker for BeltMacCore<C> where C: BlockCipherEncrypt + SmallBlockSizeUser {}
 
 impl<C> InnerInit for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     #[inline]
     fn inner_init(cipher: C) -> Self {
@@ -64,14 +63,14 @@ where
 
 impl<C> BufferKindUser for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     type BufferKind = Lazy;
 }
 
 impl<C> UpdateCore for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     #[inline]
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
@@ -101,7 +100,7 @@ where
 
 impl<C> Reset for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     #[inline(always)]
     fn reset(&mut self) {
@@ -111,7 +110,7 @@ where
 
 impl<C> FixedOutputCore for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     #[inline]
     fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
@@ -148,7 +147,7 @@ where
 
 impl<C> AlgorithmName for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("BeltMac")
@@ -157,7 +156,7 @@ where
 
 impl<C> fmt::Debug for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("BeltMacCore { ... }")
@@ -167,7 +166,7 @@ where
 #[cfg(feature = "zeroize")]
 impl<C> Drop for BeltMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     fn drop(&mut self) {
         self.state.zeroize();
@@ -176,7 +175,7 @@ where
 
 #[cfg(feature = "zeroize")]
 impl<C> ZeroizeOnDrop for BeltMacCore<C> where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone + ZeroizeOnDrop
+    C: BlockCipherEncrypt + SmallBlockSizeUser + ZeroizeOnDrop
 {
 }
 

--- a/belt-mac/src/lib.rs
+++ b/belt-mac/src/lib.rs
@@ -18,8 +18,9 @@ use digest::block_api::SmallBlockSizeUser;
 
 digest::buffer_fixed!(
     /// BeltMac instance generic over block cipher.
-    pub struct GenericBeltMac<C: BlockCipherEncrypt + SmallBlockSizeUser + Clone>(block_api::BeltMacCore<C>);
-    impl: ResetMacTraits AlgorithmName InnerInit;
+    #[derive(Clone)]
+    pub struct GenericBeltMac<C: BlockCipherEncrypt + SmallBlockSizeUser>(block_api::BeltMacCore<C>);
+    impl: BaseFixedTraits MacMarker Reset FixedOutputReset AlgorithmName InnerInit;
 );
 
 /// BeltMac instance.

--- a/cbc-mac/src/block_api.rs
+++ b/cbc-mac/src/block_api.rs
@@ -18,7 +18,7 @@ use digest::zeroize::{Zeroize, ZeroizeOnDrop};
 #[derive(Clone)]
 pub struct CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     cipher: C,
     state: Block<C>,
@@ -26,30 +26,30 @@ where
 
 impl<C> BlockSizeUser for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     type BlockSize = C::BlockSize;
 }
 
 impl<C> OutputSizeUser for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     type OutputSize = C::BlockSize;
 }
 
 impl<C> InnerUser for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     type Inner = C;
 }
 
-impl<C> MacMarker for CbcMacCore<C> where C: BlockCipherEncrypt + SmallBlockSizeUser + Clone {}
+impl<C> MacMarker for CbcMacCore<C> where C: BlockCipherEncrypt + SmallBlockSizeUser {}
 
 impl<C> InnerInit for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     #[inline]
     fn inner_init(cipher: C) -> Self {
@@ -60,14 +60,14 @@ where
 
 impl<C> BufferKindUser for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     type BufferKind = Eager;
 }
 
 impl<C> UpdateCore for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     #[inline]
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
@@ -97,7 +97,7 @@ where
 
 impl<C> Reset for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     #[inline(always)]
     fn reset(&mut self) {
@@ -107,7 +107,7 @@ where
 
 impl<C> FixedOutputCore for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     #[inline]
     fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
@@ -123,7 +123,7 @@ where
 
 impl<C> AlgorithmName for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone + AlgorithmName,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + AlgorithmName,
 {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("CbcMac<")?;
@@ -134,7 +134,7 @@ where
 
 impl<C> fmt::Debug for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone + AlgorithmName,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + AlgorithmName,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("CbcMacCore<")?;
@@ -146,7 +146,7 @@ where
 #[cfg(feature = "zeroize")]
 impl<C> Drop for CbcMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser,
 {
     fn drop(&mut self) {
         self.state.zeroize();
@@ -155,7 +155,7 @@ where
 
 #[cfg(feature = "zeroize")]
 impl<C> ZeroizeOnDrop for CbcMacCore<C> where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone + ZeroizeOnDrop
+    C: BlockCipherEncrypt + SmallBlockSizeUser + ZeroizeOnDrop
 {
 }
 

--- a/cbc-mac/src/lib.rs
+++ b/cbc-mac/src/lib.rs
@@ -18,13 +18,14 @@ use digest::block_api::CoreProxy;
 
 digest::buffer_fixed!(
     /// Generic CBC-MAC instance.
-    pub struct CbcMac<C: BlockCipherEncrypt + SmallBlockSizeUser + Clone>(block_api::CbcMacCore<C>);
-    impl: ResetMacTraits InnerInit;
+    #[derive(Clone)]
+    pub struct CbcMac<C: BlockCipherEncrypt + SmallBlockSizeUser>(block_api::CbcMacCore<C>);
+    impl: BaseFixedTraits MacMarker Reset FixedOutputReset InnerInit;
 );
 
 impl<C> AlgorithmName for CbcMac<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + Clone + AlgorithmName,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + AlgorithmName,
 {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         <Self as CoreProxy>::Core::write_alg_name(f)

--- a/cmac/src/block_api.rs
+++ b/cmac/src/block_api.rs
@@ -140,14 +140,14 @@ fn xor<N: ArraySize>(buf: &mut Array<u8, N>, data: &Array<u8, N>) {
 }
 
 /// Helper trait implemented for cipher supported by CMAC
-pub trait CmacCipher: SmallBlockSizeUser + BlockCipherEncrypt + Clone {
+pub trait CmacCipher: SmallBlockSizeUser + BlockCipherEncrypt {
     /// Double block. See the [`Dbl`] trait docs for more information.
     fn dbl(block: Block<Self>) -> Block<Self>;
 }
 
 impl<C> CmacCipher for C
 where
-    Self: SmallBlockSizeUser + BlockCipherEncrypt + Clone,
+    Self: SmallBlockSizeUser + BlockCipherEncrypt,
     Block<Self>: Dbl,
 {
     fn dbl(block: Block<Self>) -> Block<Self> {

--- a/cmac/src/lib.rs
+++ b/cmac/src/lib.rs
@@ -19,8 +19,9 @@ use digest::block_api::{AlgorithmName, CoreProxy};
 
 digest::buffer_fixed!(
     /// Generic CMAC instance.
+    #[derive(Clone)]
     pub struct Cmac<C: CmacCipher>(block_api::CmacCore<C>);
-    impl: ResetMacTraits InnerInit;
+    impl: BaseFixedTraits MacMarker Reset FixedOutputReset InnerInit;
 );
 
 impl<C: CmacCipher + AlgorithmName> AlgorithmName for Cmac<C> {

--- a/pmac/src/block_api.rs
+++ b/pmac/src/block_api.rs
@@ -217,7 +217,7 @@ fn xor<N: ArraySize>(buf: &mut Array<u8, N>, data: &Array<u8, N>) {
 ///
 /// Currently this trait is implemented for all block cipher encryptors
 /// with block size equal to 64 and 128 bits.
-pub trait PmacCipher: SmallBlockSizeUser + BlockCipherEncrypt + Clone {
+pub trait PmacCipher: SmallBlockSizeUser + BlockCipherEncrypt {
     /// Double block. See the [`Dbl`] trait docs for more information.
     fn dbl(block: Block<Self>) -> Block<Self>;
     /// Reverse double block.. See the [`Dbl`] trait docs for more information.
@@ -226,7 +226,7 @@ pub trait PmacCipher: SmallBlockSizeUser + BlockCipherEncrypt + Clone {
 
 impl<C> PmacCipher for C
 where
-    Self: SmallBlockSizeUser + BlockCipherEncrypt + Clone,
+    Self: SmallBlockSizeUser + BlockCipherEncrypt,
     Block<Self>: Dbl,
 {
     fn dbl(block: Block<Self>) -> Block<Self> {

--- a/pmac/src/lib.rs
+++ b/pmac/src/lib.rs
@@ -19,8 +19,9 @@ use digest::block_api::{AlgorithmName, CoreProxy};
 
 digest::buffer_fixed!(
     /// Generic PMAC instance with `LC_SIZE` = 20.
+    #[derive(Clone)]
     pub struct Pmac<C: PmacCipher>(block_api::PmacCore<C, 20>);
-    impl: ResetMacTraits InnerInit;
+    impl: BaseFixedTraits MacMarker Reset FixedOutputReset InnerInit;
 );
 
 impl<C: PmacCipher + AlgorithmName> AlgorithmName for Pmac<C> {

--- a/retail-mac/src/block_api.rs
+++ b/retail-mac/src/block_api.rs
@@ -21,7 +21,7 @@ use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 #[derive(Clone)]
 pub struct RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt,
 {
     cipher: C,
     cipher_prime: C,
@@ -30,21 +30,21 @@ where
 
 impl<C> BlockSizeUser for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt,
 {
     type BlockSize = C::BlockSize;
 }
 
 impl<C> OutputSizeUser for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt,
 {
     type OutputSize = C::BlockSize;
 }
 
 impl<C> KeySizeUser for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt,
     <C as SmallBlockSizeUser>::_BlockSize: Mul<U2>,
     Prod<<C as SmallBlockSizeUser>::_BlockSize, U2>: ArraySize,
 {
@@ -52,20 +52,20 @@ where
 }
 
 impl<C> MacMarker for RetailMacCore<C> where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt
 {
 }
 
 impl<C> BufferKindUser for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt,
 {
     type BufferKind = Eager;
 }
 
 impl<C> KeyInit for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone + KeyInit,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + KeyInit,
     <C as SmallBlockSizeUser>::_BlockSize: Mul<U2>,
     Prod<<C as SmallBlockSizeUser>::_BlockSize, U2>: ArraySize,
 {
@@ -88,7 +88,7 @@ where
 
 impl<C> UpdateCore for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt,
 {
     #[inline]
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
@@ -118,7 +118,7 @@ where
 
 impl<C> Reset for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt,
 {
     #[inline(always)]
     fn reset(&mut self) {
@@ -128,7 +128,7 @@ where
 
 impl<C> FixedOutputCore for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt,
 {
     #[inline]
     fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
@@ -150,7 +150,7 @@ where
 
 impl<C> AlgorithmName for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone + AlgorithmName,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + AlgorithmName,
 {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("RetailMac<")?;
@@ -161,7 +161,7 @@ where
 
 impl<C> fmt::Debug for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone + AlgorithmName,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + AlgorithmName,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("RetailMacCore<")?;
@@ -173,7 +173,7 @@ where
 #[cfg(feature = "zeroize")]
 impl<C> Drop for RetailMacCore<C>
 where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone,
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt,
 {
     fn drop(&mut self) {
         self.state.zeroize();
@@ -182,7 +182,7 @@ where
 
 #[cfg(feature = "zeroize")]
 impl<C> ZeroizeOnDrop for RetailMacCore<C> where
-    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + Clone + ZeroizeOnDrop
+    C: BlockCipherEncrypt + SmallBlockSizeUser + BlockCipherDecrypt + ZeroizeOnDrop
 {
 }
 

--- a/retail-mac/src/lib.rs
+++ b/retail-mac/src/lib.rs
@@ -26,13 +26,13 @@ use digest::{
 
 digest::buffer_fixed!(
     /// Generic Retail MAC instance.
-    pub struct RetailMac<C: BlockCipherEncrypt + BlockCipherDecrypt + SmallBlockSizeUser + Clone>(RetailMacCore<C>);
-    impl: ResetMacTraits;
+    pub struct RetailMac<C: BlockCipherEncrypt + BlockCipherDecrypt + SmallBlockSizeUser >(RetailMacCore<C>);
+    impl: BaseFixedTraits MacMarker Reset FixedOutputReset;
 );
 
 impl<C> KeySizeUser for RetailMac<C>
 where
-    C: BlockCipherEncrypt + BlockCipherDecrypt + SmallBlockSizeUser + Clone,
+    C: BlockCipherEncrypt + BlockCipherDecrypt + SmallBlockSizeUser,
     <C as SmallBlockSizeUser>::_BlockSize: Mul<U2>,
     Prod<<C as SmallBlockSizeUser>::_BlockSize, U2>: ArraySize,
 {
@@ -41,7 +41,7 @@ where
 
 impl<C> KeyInit for RetailMac<C>
 where
-    C: BlockCipherEncrypt + BlockCipherDecrypt + SmallBlockSizeUser + Clone + KeyInit,
+    C: BlockCipherEncrypt + BlockCipherDecrypt + SmallBlockSizeUser + KeyInit,
     <C as SmallBlockSizeUser>::_BlockSize: Mul<U2>,
     Prod<<C as SmallBlockSizeUser>::_BlockSize, U2>: ArraySize,
 {
@@ -64,7 +64,7 @@ where
 
 impl<C> AlgorithmName for RetailMac<C>
 where
-    C: BlockCipherEncrypt + BlockCipherDecrypt + SmallBlockSizeUser + Clone + AlgorithmName,
+    C: BlockCipherEncrypt + BlockCipherDecrypt + SmallBlockSizeUser + AlgorithmName,
 {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         <Self as CoreProxy>::Core::write_alg_name(f)


### PR DESCRIPTION
The bounds are necessary only for implementation of `Clone` for buffered types and it can be handled with a simple `#[derive(Clone)]`. Unfortunately, `Clone` is part of `(Reset)MacTraits`, so we have to use a more granular listing of traits.