### PR TITLE
Release new versions dependent on `cipher` v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "belt-mac"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "belt-block",
  "cipher",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "cbc-mac"
-version = "0.2.0-rc.5"
+version = "0.2.0"
 dependencies = [
  "aes",
  "cipher",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-rc.5"
+version = "0.8.0"
 dependencies = [
  "aes",
  "cipher",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "pmac"
-version = "0.8.0-rc.5"
+version = "0.8.0"
 dependencies = [
  "aes",
  "cipher",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "retail-mac"
-version = "0.1.0-pre.1"
+version = "0.1.0"
 dependencies = [
  "aes",
  "cipher",

--- a/belt-mac/CHANGELOG.md
+++ b/belt-mac/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2026-04-10)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85
 - Relax MSRV policy and allow MSRV bumps in patch releases

--- a/belt-mac/Cargo.toml
+++ b/belt-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-mac"
-version = "0.2.0-pre"
+version = "0.2.0"
 description = "MAC specified by the BelT standard"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cbc-mac/CHANGELOG.md
+++ b/cbc-mac/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2026-04-10)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85
 - Relax MSRV policy and allow MSRV bumps in patch releases

--- a/cbc-mac/Cargo.toml
+++ b/cbc-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbc-mac"
-version = "0.2.0-rc.5"
+version = "0.2.0"
 description = "Implementation of Cipher Block Chaining Message Authentication Code (CBC-MAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cmac/CHANGELOG.md
+++ b/cmac/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.0 (UNRELEASED)
+## 0.8.0 (2026-04-10)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85
 - Relax MSRV policy and allow MSRV bumps in patch releases

--- a/cmac/Cargo.toml
+++ b/cmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmac"
-version = "0.8.0-rc.5"
+version = "0.8.0"
 description = "Generic implementation of Cipher-based Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pmac/CHANGELOG.md
+++ b/pmac/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.0 (UNRELEASED)
+## 0.8.0 (2026-04-10)
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85
 - Relax MSRV policy and allow MSRV bumps in patch releases

--- a/pmac/Cargo.toml
+++ b/pmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmac"
-version = "0.8.0-rc.5"
+version = "0.8.0"
 description = "Generic implementation of Parallelizable Message Authentication Code"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/retail-mac/CHANGELOG.md
+++ b/retail-mac/CHANGELOG.md
@@ -5,5 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 (UNRELEASED)
-- Initial release
+## 0.1.0 (2026-04-10)
+- Initial release ([#170])
+
+[#170]: https://github.com/RustCrypto/MACs/pull/170

--- a/retail-mac/Cargo.toml
+++ b/retail-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retail-mac"
-version = "0.1.0-pre.1"
+version = "0.1.0"
 description = "Implementation of Retail Message Authentication Code (Retail MAC)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Most crates contain the following changelog:

### Changed
- Edition changed to 2024 and MSRV bumped to 1.85
- Relax MSRV policy and allow MSRV bumps in patch releases
- Update to `digest` v0.11
- Update to `cipher` v0.5
- Replace type aliases with newtypes ([#186])

### Removed
- `std` crate feature ([#186])

[#186]: https://github.com/RustCrypto/MACs/pull/186